### PR TITLE
Update libcnb to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,22 +559,23 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libcnb"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a8206c9c5004aa37c8369e27494cdda7744611f4b39f95b5bbbbd5a9365c20"
+checksum = "4d67f6f6f7dd0a13fce25a9247fd9a0e5cbe97c8431fee0008c674602e36c9e4"
 dependencies = [
  "libcnb-data",
  "libcnb-proc-macros",
  "serde",
+ "stacker",
  "thiserror",
  "toml",
 ]
 
 [[package]]
 name = "libcnb-data"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498e6ba7cfd2520053c75d1a3f4f98f09d0e45103f043f7f8cfe422b236b8e4b"
+checksum = "52cd3749d2c63a77a4d2b069904ecb526977692352186ec3094b15df50c71ee3"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
@@ -585,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.2.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac843541f7874babc40106a52e35972931f66ca95e5adabbc8b20ca36063e5ea"
+checksum = "3e245f2e25a5fc10593db933f25e739f9c5a6d0f944c3bebac6b282e0a9888a1"
 dependencies = [
  "cargo_metadata",
  "libcnb-data",
@@ -597,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.3.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21023e1598df3f6fea1b188a34ce06ca41181f03ed3d71169ebaa58c8cfd278b"
+checksum = "f298d2d11525f72ea88e0f529372d11e62b1410c2f11a65c8eb061581597710f"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
@@ -609,14 +610,15 @@ dependencies = [
 
 [[package]]
 name = "libcnb-test"
-version = "0.6.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8111541bbccb29e423bc8904f0d750793a484601fd52b177bd478af544c6f2"
+checksum = "a8987577ad4be4171cbb730e7a23be913a5a83da624a6ea9eb5457ab9a55c405"
 dependencies = [
  "bollard",
  "cargo_metadata",
  "fastrand",
  "fs_extra",
+ "libcnb-data",
  "libcnb-package",
  "serde",
  "tempfile",
@@ -626,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "libherokubuildpack"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896572dbc018df95e8539bfdadd8da6fc5646d41c2f8cadfe31075b0ef7bc57c"
+checksum = "ea1621294a166cafb93e9df130da45d951ed26910b209d4c356684028e53b4f4"
 dependencies = [
  "flate2",
  "libcnb",
@@ -766,6 +768,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f446d0a6efba22928558c4fb4ce0b3fd6c89b0061343e390bf01a703742b8125"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -964,6 +975,19 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 rust-version = "1.62"
 
 [dependencies]
-libcnb = "0.9"
-libherokubuildpack = "0.9"
+libcnb = "0.10"
+libherokubuildpack = "0.10"
 serde = "1.0"
 serde_json = "1.0"
 tempfile = "3.3"
@@ -22,4 +22,4 @@ flate2 = { version = "1.0.24", default-features = false, features = ["zlib"] }
 tar = "0.4.38"
 
 [dev-dependencies]
-libcnb-test = "0.6"
+libcnb-test = "0.10"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.6"
+api = "0.8"
 
 [buildpack]
 id = "heroku/go"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use layers::dist::{DistLayer, DistLayerError};
 use layers::target::{TargetLayer, TargetLayerError};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::build_plan::BuildPlanBuilder;
-use libcnb::data::launch::Launch;
+use libcnb::data::launch::LaunchBuilder;
 use libcnb::data::layer_name;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericMetadata;
@@ -141,7 +141,7 @@ impl Buildpack for GoBuildpack {
         }
 
         BuildResultBuilder::new()
-            .launch(Launch::new().processes(procs))
+            .launch(LaunchBuilder::new().processes(procs).build())
             .build()
     }
 


### PR DESCRIPTION
Update `libcnb` and `libherokubuildpack` to `0.10.0` and therefore to buildpack API `0.8` as well. I didn't add a CHANGELOG entry about the version bump as this isn't released yet so there is no real change for users here.

Closes GUS-W-11681878