### PR TITLE
Change dependabot frequency and add labeling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,12 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    labels:
+      - "skip changelog"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    labels:
+      - "skip changelog"


### PR DESCRIPTION
This changes the dependabot frequency to monthly to match our other buildpacks. It also adds the "skip changelog" label, which should make merging dependabot PRs slightly easier.