### PR TITLE
Add buildpack release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release Buildpack
 
 on:
   workflow_dispatch:
+  push:
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,29 +11,36 @@ jobs:
     name: Release heroku/go
     runs-on: ubuntu-20.04 # ubuntu-latest currently resolves to 18.04 which does not have aws-cli 2.x yet
     steps:
+
       - id: checkout
         name: "Checkout code"
         uses: actions/checkout@v3
+
       - id: setup-pack
         name: "Setup pack"
         uses: buildpacks/github-actions/setup-pack@v4.8.1
+
       - id: install-musl-tools
         run: sudo apt-get install musl-tools
+
       - id: install-rust-toolchain
         name: "Install Rust toolchain"
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: "x86_64-unknown-linux-musl"
+
       - id: install-libcnb-cargo
         name: "Install libcnb-cargo"
         uses: actions-rs/install@v0.1
         with:
           crate: libcnb-cargo
           version: latest
+
       - id: compile
         name: "Compile buildpack"
         run: cargo libcnb package --release
+
       - id: metadata
         name: "Read buildpack metadata"
         run: |
@@ -43,22 +50,27 @@ jobs:
           echo "buildpack_version=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .buildpack.version)" >> $GITHUB_ENV
           echo "buildpack_repo=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .metadata.release.image.repository)" >> $GITHUB_ENV
           echo "buildpack_file=heroku_go.cnb" >> $GITHUB_ENV
+
       - id: package-buildpack
         name: "Package buildpack"
         run: pack buildpack package --path "${{ env.buildpack_path }}" --format file "${{ env.buildpack_file}}"
+
       - id: dockerhub-login
         name: "Login to Docker Hub"
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
       - id: publish-image
         name: "Publish buildpack to image registry"
         run: pack buildpack package --path "${{ env.buildpack_path }}" --publish "${{ env.buildpack_repo }}:${{ env.buildpack_version }}"
+
       - id: image-digest
         name: "Calculate buildpack image digest"
         run: |
           echo "buildpack_digest=$(crane digest ${{ env.buildpack_repo }}:${{ env.buildpack_version }})" >> $GITHUB_ENV
+
       - id: add-registry-entry
         name: "Request Buildpack Registry Entry"
         uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.0
@@ -67,6 +79,7 @@ jobs:
           id: ${{ env.buildpack_id }}
           version: ${{ env.buildpack_version }}
           address: ${{ env.buildpack_repo }}@${{ env.buildpack_digest }}
+
       - id: create_release
         name: Create Release
         uses: actions/create-release@v1
@@ -79,6 +92,7 @@ jobs:
             See the [CHANGELOG](./CHANGELOG.md) for details.
           draft: false
           prerelease: false
+
       - id: upload_package
         name: Upload buildpackage to release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
           echo "buildpack_path=$BUILDPACK_PATH" >> $GITHUB_ENV
           echo "buildpack_id=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .buildpack.id)" >> $GITHUB_ENV
           echo "buildpack_version=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .buildpack.version)" >> $GITHUB_ENV
-          echo "buildpack_repo=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .metadata.release.image.repository" >> $GITHUB_ENV
-          echo "buildpack_file=buildpack.cnb"
+          echo "buildpack_repo=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .metadata.release.image.repository)" >> $GITHUB_ENV
+          echo "buildpack_file=heroku_go.cnb" >> $GITHUB_ENV
       - id: package-buildpack
         name: "Package buildpack"
         run: pack buildpack package --path "${{ env.buildpack_path }}" --format file "${{ env.buildpack_file}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,14 @@ name: Release Buildpack
 
 on:
   workflow_dispatch:
-  push:
+
+permissions:
+  contents: write
 
 jobs:
   release:
     name: Release heroku/go
     runs-on: ubuntu-20.04 # ubuntu-latest currently resolves to 18.04 which does not have aws-cli 2.x yet
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - id: checkout
         name: "Checkout code"
@@ -18,12 +17,6 @@ jobs:
       - id: setup-pack
         name: "Setup pack"
         uses: buildpacks/github-actions/setup-pack@v4.8.1
-      - id: dockerhub-login
-        name: "Login to Docker Hub"
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - id: install-musl-tools
         run: sudo apt-get install musl-tools
       - id: install-rust-toolchain
@@ -53,6 +46,12 @@ jobs:
       - id: package-buildpack
         name: "Package buildpack"
         run: pack buildpack package --path "${{ env.buildpack_path }}" --format file "${{ env.buildpack_file}}"
+      - id: dockerhub-login
+        name: "Login to Docker Hub"
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - id: publish-image
         name: "Publish buildpack to image registry"
         run: pack buildpack package --path "${{ env.buildpack_path }}" --publish "${{ env.buildpack_repo }}:${{ env.buildpack_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
       - id: compile
         name: "Compile buildpack"
         run: cargo libcnb package --release
-      - id: set-metadata
-        name: "Set buildpack metadata"
+      - id: metadata
+        name: "Read buildpack metadata"
         run: |
           export BUILDPACK_PATH="target/buildpack/release/heroku_go"
           echo "buildpack_path=$BUILDPACK_PATH" >> $GITHUB_ENV
@@ -56,6 +56,10 @@ jobs:
       - id: publish-image
         name: "Publish buildpack to image registry"
         run: pack buildpack package --path "${{ env.buildpack_path }}" --publish "${{ env.buildpack_repo }}:${{ env.buildpack_version }}"
+      - id: image-digest
+        name: "Calculate buildpack image digest"
+        run: |
+          echo "buildpack_digest=$(crane digest ${{ env.buildpack_repo }}:${{ env.buildpack_version }})" >> $GITHUB_ENV
       - id: add-registry-entry
         name: "Request Buildpack Registry Entry"
         uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.0
@@ -63,7 +67,7 @@ jobs:
           token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}
           id: ${{ env.buildpack_id }}
           version: ${{ env.buildpack_version }}
-          address: ${{ env.buildpack_repo }}@$(crane digest "${{ env.buildpack_repo }}:${{ env.buildpack_version }}")
+          address: ${{ env.buildpack_repo }}@${{ env.buildpack_digest }}
       - id: create_release
         name: Create Release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,12 @@ jobs:
       - id: setup-pack
         name: "Setup pack"
         uses: buildpacks/github-actions/setup-pack@v4.8.1
-      - id: login
-        name: "Login to public ECR"
+      - id: dockerhub-login
+        name: "Login to Docker Hub"
         uses: docker/login-action@v2
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        env:
-          AWS_REGION: us-east-1
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - id: install-musl-tools
         run: sudo apt-get install musl-tools
       - id: install-rust-toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release Buildpack
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Release heroku/go
+    runs-on: ubuntu-20.04 # ubuntu-latest currently resolves to 18.04 which does not have aws-cli 2.x yet
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - id: checkout
+        name: "Checkout code"
+        uses: actions/checkout@v3
+      - id: setup-pack
+        name: "Setup pack"
+        uses: buildpacks/github-actions/setup-pack@v4.8.1
+      - id: login
+        name: "Login to public ECR"
+        uses: docker/login-action@v2
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: us-east-1
+      - id: install-musl-tools
+        run: sudo apt-get install musl-tools
+      - id: install-rust-toolchain
+        name: "Install Rust toolchain"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: "x86_64-unknown-linux-musl"
+      - id: install-libcnb-cargo
+        name: "Install libcnb-cargo"
+        uses: actions-rs/install@v0.1
+        with:
+          crate: libcnb-cargo
+          version: latest
+      - id: compile
+        name: "Compile buildpack"
+        run: cargo libcnb package --release
+      - id: set-metadata
+        name: "Set buildpack metadata"
+        run: |
+          export BUILDPACK_PATH="target/buildpack/release/heroku_go"
+          echo "buildpack_path=$BUILDPACK_PATH" >> $GITHUB_ENV
+          echo "buildpack_id=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .buildpack.id)" >> $GITHUB_ENV
+          echo "buildpack_version=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .buildpack.version)" >> $GITHUB_ENV
+          echo "buildpack_repo=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .metadata.release.image.repository" >> $GITHUB_ENV
+          echo "buildpack_file=buildpack.cnb"
+      - id: package-buildpack
+        name: "Package buildpack"
+        run: pack buildpack package --path "${{ env.buildpack_path }}" --format file "${{ env.buildpack_file}}"
+      - id: publish-image
+        name: "Publish buildpack to image registry"
+        run: pack buildpack package --path "${{ env.buildpack_path }}" --publish "${{ env.buildpack_repo }}:${{ env.buildpack_version }}"
+      - id: add-registry-entry
+        name: "Request Buildpack Registry Entry"
+        uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.0
+        with:
+          token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}
+          id: ${{ env.buildpack_id }}
+          version: ${{ env.buildpack_version }}
+          address: ${{ env.buildpack_repo }}@$(crane digest "${{ env.buildpack_repo }}:${{ env.buildpack_version }}")
+      - id: create_release
+        name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.buildpack_id }}_${{ env.buildpack_version }}
+          release_name: ${{ env.buildpack_id }} ${{ env.buildpack_version }}
+          body: |
+            See the [CHANGELOG](./CHANGELOG.md) for details.
+          draft: false
+          prerelease: false
+      - id: upload_package
+        name: Upload buildpackage to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.buildpack_file }}
+          tag: ${{ env.buildpack_id }}_${{ env.buildpack_version }}
+          overwrite: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] 2022/12/01
+
 - Initial implementation using libcnb.rs ([#1](https://github.com/heroku/buildpacks-go/pull/1))

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,3 +16,10 @@ id = "heroku-20"
 
 [[stacks]]
 id = "heroku-22"
+
+[metadata]
+
+[metadata.release]
+
+[metadata.release.docker]
+repository = "public.ecr.aws/heroku-buildpacks/heroku-go-buildpack"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -21,5 +21,5 @@ id = "heroku-22"
 
 [metadata.release]
 
-[metadata.release.docker]
-repository = "public.ecr.aws/heroku-buildpacks/heroku-go-buildpack"
+[metadata.release.image]
+repository = "docker.io/heroku/buildpack-go"


### PR DESCRIPTION
This adds release automation via GitHub Actions. Images are published to https://hub.docker.com/r/heroku/buildpack-go, then registered at https://registry.buildpacks.io/buildpacks/heroku/go, then published to a release on this repo: https://github.com/heroku/buildpacks-go/releases/tag/heroku%2Fgo_0.1.0.

Example successful action: https://github.com/heroku/buildpacks-go/actions/runs/3594880722/jobs/6053699160