### PR TITLE
Add inventory automation

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set Diff Message
         run: echo "DIFF_MSG=$(cargo run --bin diff_inventory inventory.toml)" >> $GITHUB_OUTPUT
       - name: Rebuild Inventory
-        run: "cargo run --bin update_inventory"
+        run: "cargo run --bin update_inventory inventory.toml"
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.DIFF_MSG }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
       - name: Create Pull Request

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -6,7 +6,7 @@ on:
     - cron: '00 4 * * 1-5'
 
 permissions:
-  workflows: write
+  actions: write
   contents: write
   pull-requests: write
 

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -1,0 +1,34 @@
+name: Update Inventory
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 4 * * 1-5'
+
+jobs:
+  update-go-inventory:
+    name: Update Go Inventory
+    runs-on: pub-hk-ubuntu-22.04-small
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - id: install-rust-toolchain
+        name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - id: set-diff-msg
+        name: Set Diff Message
+        run: echo "::set-output name=msg::$(cargo run --bin diff_inventory inventory.toml)"
+      - name: Rebuild Inventory
+        run: "cargo run --bin update_inventory"
+      - name: Update Changelog
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: "Update Go Inventory"
+          commit-message: "Update Inventory for heroku/go\n\n${{ steps.set-diff-msg.outputs.msg }}"
+          branch: update-go-inventory
+          labels: "automation"
+          body: "Automated pull-request to update heroku/go inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '00 4 * * 1-5'
 
+permissions:
+  workflows: write
+  contents: write
+  pull-requests: write
+
 jobs:
   update-go-inventory:
     name: Update Go Inventory

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -1,6 +1,5 @@
 name: Update Inventory
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '00 4 * * 1-5'

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -19,16 +19,16 @@ jobs:
           toolchain: stable
       - id: set-diff-msg
         name: Set Diff Message
-        run: echo "::set-output name=msg::$(cargo run --bin diff_inventory inventory.toml)"
+        run: echo "DIFF_MSG=$(cargo run --bin diff_inventory inventory.toml)" >> $GITHUB_OUTPUT
       - name: Rebuild Inventory
         run: "cargo run --bin update_inventory"
       - name: Update Changelog
-        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
+        run: echo "${{ steps.set-diff-msg.outputs.DIFF_MSG }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
           title: "Update Go Inventory"
-          commit-message: "Update Inventory for heroku/go\n\n${{ steps.set-diff-msg.outputs.msg }}"
+          commit-message: "Update Inventory for heroku/go\n\n${{ steps.set-diff-msg.outputs.DIFF_MSG }}"
           branch: update-go-inventory
           labels: "automation"
           body: "Automated pull-request to update heroku/go inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -31,4 +31,4 @@ jobs:
           commit-message: "Update Inventory for heroku/go\n\n${{ steps.set-diff-msg.outputs.DIFF_MSG }}"
           branch: update-go-inventory
           labels: "automation"
-          body: "Automated pull-request to update heroku/go inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
+          body: "Automated pull-request to update heroku/go inventory:\n\n${{ steps.set-diff-msg.outputs.DIFF_MSG }}"

--- a/src/bin/diff_inventory.rs
+++ b/src/bin/diff_inventory.rs
@@ -1,0 +1,45 @@
+#![warn(clippy::pedantic)]
+
+use heroku_go_buildpack::inv::{list_github_go_versions, Artifact, Inventory};
+use std::collections::HashSet;
+
+/// Prints a human-readable software inventory difference. Useful
+/// for generating commit messages and changelogs for automated inventory
+/// updates.
+fn main() {
+    let inventory_path = std::env::args().nth(1).unwrap_or_else(|| {
+        eprintln!("$ diff_inventory path/to/inventory.toml");
+        std::process::exit(1);
+    });
+
+    let upstream_versions: HashSet<String> = list_github_go_versions()
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to fetch upstream go versions on GitHub: {e}");
+            std::process::exit(1)
+        })
+        .into_iter()
+        .filter_map(|v| Artifact::build(v).ok())
+        .map(|a| a.go_version)
+        .collect();
+
+    let local_versions: HashSet<String> = Inventory::read(&inventory_path)
+        .unwrap_or_else(|e| {
+            eprintln!("Error reading inventory at '{inventory_path}': {e}");
+            std::process::exit(1);
+        })
+        .artifacts
+        .iter()
+        .map(|r| r.go_version.to_string())
+        .collect();
+
+    let mut new_versions: Vec<String> = upstream_versions
+        .difference(&local_versions)
+        .map(String::to_string)
+        .collect();
+
+    new_versions.sort();
+
+    if !new_versions.is_empty() {
+        println!("Added {}.", new_versions.join(", "));
+    }
+}


### PR DESCRIPTION
This `inventory.yml` action is similar to what we have for the Node.js Classic and Cloud Native Buildpacks. Here's how it works:

1. runs on a regular schedule (weeknights)
2. Attempts to generate a human readable list of go versions that are tagged in the github.com/golang/go repo, but not included in inventory.toml with `diff_inventory.rs` (this output is used for changelog and commit messages).
3. Adds the above output to the changelog.
4. Updates the inventory.toml with the missing versions. Again, by checking for versions tagged in github.com/golang/go repo, then also looking up the sha from Golang's binary host.
5. Opens a PR against this repo with the changes, using the diff message from before.

Example PR that this automation generated: #75