### PR TITLE
Prepare 0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3] 2023/03/27
+## [0.1.3] 2023/04/11
 
 - Added go1.19.8, go1.20.3.
 - Added go1.19.6, go1.19.7, go1.20.1, go1.20.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] 2023/03/27
+
 - Added go1.19.8, go1.20.3.
 - Added go1.19.6, go1.19.7, go1.20.1, go1.20.2.
+
 ## [0.1.2] 2023/02/06
+
 - Added go1.20
 
 ## [0.1.1] 2023/01/23

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.8"
 
 [buildpack]
 id = "heroku/go"
-version = "0.1.2"
+version = "0.1.3"
 name = "Heroku Go"
 homepage = "https://github.com/heroku/buildpacks-go"
 keywords = ["go", "golang", "heroku"]


### PR DESCRIPTION
Updates the buildpack version and the changelog for 0.1.3, which includes new go versions.