### PR TITLE
Use IP address whitelisted runner for releasing buildpacks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   release:
     name: Release heroku/go
-    runs-on: ubuntu-20.04 # ubuntu-latest currently resolves to 18.04 which does not have aws-cli 2.x yet
+    runs-on: pub-hk-ubuntu-22.04-small
     steps:
 
       - id: checkout


### PR DESCRIPTION
The release automation is failing due to IP whitelisting: https://github.com/heroku/buildpacks-go/actions/runs/4929777921/jobs/8809844516#step:16:19.

This PR changes the release workflow to use an IP whitelisted runner.