### PR TITLE
Update to CNB Buildpack API 0.9 and libcnb.rs to 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update to CNB Buildpack API version 0.9. ([#101](https://github.com/heroku/buildpacks-go/pull/101))
+
 ## [0.1.4] 2023/05/09
 
 - Added go1.19.9, go1.20.4.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libcnb"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4fd7573558173267930e31446da65a0275770bde88847cad4b4cf9a6ff8375"
+checksum = "027cd4a736600564c4e7aebf124eabb9d7dc622bcfeefb414cc7c4c7d7ac6595"
 dependencies = [
  "libcnb-data",
  "libcnb-proc-macros",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-data"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0112478d479c8900929894426818bea8e769ce923536a58baac719d3ca4dcb"
+checksum = "6e8840246c7aced3307fa193edc5d26482f92f992986a33860b6b3b523a67975"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacd18d358a1078cf48f518ef8398c504f8d4fc691ba2e8773bafa1a71d66b59"
+checksum = "27205236a28660f7395598a3f65afb9315de8ce3054c39375b0be673fa6288e7"
 dependencies = [
  "cargo_metadata",
  "libcnb-data",
@@ -688,21 +688,21 @@ dependencies = [
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5930cea22615255081c0c44b902e6e8b37a824ebe1374a7c7d52724d5b7d6e4e"
+checksum = "c9e31cc93a20d00f1d54ecb55dcff681669871e6d8a8b63ac0320e77fca1987c"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "libcnb-test"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86e8c1847c8ba3c37e30841ee241887203110f4373731e7967706ab77c42b7d"
+checksum = "ff3f26e5f4ad90ea4036618dcba858c567f8c46a281daa72856eab3be0972885"
 dependencies = [
  "bollard",
  "cargo_metadata",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "libherokubuildpack"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878674906e0140191f89047ef1e8c142cb31becce91b4e64b1b6419fe03da7c1"
+checksum = "4ee2764ebf688454c4fcbcd7c52ff277b5cb2e196c502ff4ce92de563cb10ea2"
 dependencies = [
  "termcolor",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ rust-version = "1.66"
 
 [dependencies]
 flate2 = { version = "1", default-features = false, features = ["zlib"] }
-libcnb = "0.11"
-libherokubuildpack = { version = "0.11", default-features = false, features = ["log"] }
+libcnb = "0.12"
+libherokubuildpack = { version = "0.12", default-features = false, features = ["log"] }
 regex = "1"
 semver = "1"
 serde = "1"
@@ -22,4 +22,4 @@ toml = "0.7"
 ureq = { version = "2", features = ["json"] }
 
 [dev-dependencies]
-libcnb-test = "0.11"
+libcnb-test = "0.12"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.9"
 
 [buildpack]
 id = "heroku/go"

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ impl Buildpack for GoBuildpack {
         let procs = proc::build_procs(&packages).map_err(GoBuildpackError::Proc)?;
         log_info("Detected processes:");
         for proc in &procs {
-            log_info(format!("  - {}: {}", proc.r#type, proc.command));
+            log_info(format!("  - {}: {}", proc.r#type, proc.command.join(" ")));
         }
 
         BuildResultBuilder::new()

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -38,7 +38,7 @@ pub(crate) fn build_procs(pkgs: &[String]) -> Result<Vec<Process>, Error> {
             .parse::<ProcessType>()?;
 
         procs.push(
-            ProcessBuilder::new(proc_name.clone(), proc_name.to_string())
+            ProcessBuilder::new(proc_name.clone(), [proc_name.to_string()])
                 .default(proc_name.to_string() == "web")
                 .build(),
         );

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -66,7 +66,7 @@ mod tests {
         for (i, name) in ["kubernetes", "web"].iter().enumerate() {
             let proc = procs.get(i).expect("missing process in build_procs");
             assert_eq!(*name, proc.r#type.to_string());
-            assert_eq!("kubernetes", proc.command);
+            assert_eq!("kubernetes", proc.command.join(" "));
         }
     }
 
@@ -75,7 +75,7 @@ mod tests {
         let procs = build_procs(&[String::from("example.com/web")])
             .expect("unexpected error with build_procs");
         assert_eq!(procs.len(), 1);
-        assert_eq!(procs[0].command, "web");
+        assert_eq!(procs[0].command, ["web"]);
     }
 
     #[test]


### PR DESCRIPTION
Updates CNB Buildpack API to 0.9 and libcnb.rs to 0.12. This required some changes to `Process`, which are explained upstream: https://github.com/heroku/libcnb.rs/releases/tag/v0.12.0.

