### PR TITLE
Use the shared release automation for Go buildpacks

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,28 @@
+name: Prepare Buildpack Releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Bump"
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-prepare-release.yml@main
+    with:
+      bump: ${{ inputs.bump }}
+      declarations_starting_version: 1.0.0
+      app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+    secrets:
+      app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -22,7 +22,6 @@ jobs:
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-prepare-release.yml@main
     with:
       bump: ${{ inputs.bump }}
-      declarations_starting_version: 1.0.0
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,6 +1,7 @@
 name: Prepare Buildpack Releases
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       bump:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,7 +1,6 @@
 name: Prepare Buildpack Releases
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       bump:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,106 +1,81 @@
-name: Release Buildpack
+name: Release Buildpacks
 
 on:
   workflow_dispatch:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  release:
-    name: Release heroku/go
-    runs-on: pub-hk-ubuntu-22.04-small
-    steps:
+  detect:
+    name: Detecting Buildpacks
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-detect.yml@main
 
-      - id: checkout
-        name: "Checkout code"
-        uses: actions/checkout@v3
+  package:
+    name: ${{ matrix.buildpack_id }}
+    needs: [ detect ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-package.yml@main
+    with:
+      buildpack_id: ${{ matrix.buildpack_id }}
+      buildpack_dir: ${{ matrix.buildpack_dir }}
+      buildpack_version: ${{ matrix.buildpack_version }}
+      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
 
-      - id: setup-pack
-        name: "Setup pack"
-        uses: buildpacks/github-actions/setup-pack@v5.2.0
+  publish-docker:
+    name: ${{ matrix.buildpack_id }}
+    needs: [ detect, package ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-docker.yml@main
+    with:
+      buildpack_id: ${{ matrix.buildpack_id }}
+      buildpack_version: ${{ matrix.buildpack_version }}
+      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
+      docker_repository: ${{ matrix.docker_repository }}
+    secrets:
+      docker_hub_user: ${{ secrets.DOCKER_HUB_USER }}
+      docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Install yj
-        uses: buildpacks/github-actions/setup-tools@v5.2.0
+  publish-github:
+    name: ${{ matrix.buildpack_id }}
+    needs: [ detect, package ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-github.yml@main
+    with:
+      buildpack_version: ${{ matrix.buildpack_version }}
+      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
 
-      - id: install-musl-tools
-        run: sudo apt-get install musl-tools
+  publish-cnb:
+    name: ${{ matrix.buildpack_id }}
+    needs: [ detect, publish-docker ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-cnb-registry.yml@main
+    with:
+      buildpack_id: ${{ matrix.buildpack_id }}
+      buildpack_version: ${{ matrix.buildpack_version }}
+      docker_repository: ${{ matrix.docker_repository }}
+    secrets:
+      cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}
 
-      - id: install-rust-toolchain
-        name: "Install Rust toolchain"
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: "x86_64-unknown-linux-musl"
-
-      - id: install-libcnb-cargo
-        name: "Install libcnb-cargo"
-        uses: actions-rs/install@v0.1
-        with:
-          crate: libcnb-cargo
-          version: latest
-
-      - id: compile
-        name: "Compile buildpack"
-        run: cargo libcnb package --release
-
-      - id: metadata
-        name: "Read buildpack metadata"
-        run: |
-          export BUILDPACK_PATH="target/buildpack/release/heroku_go"
-          echo "buildpack_path=$BUILDPACK_PATH" >> $GITHUB_ENV
-          echo "buildpack_id=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .buildpack.id)" >> $GITHUB_ENV
-          echo "buildpack_version=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .buildpack.version)" >> $GITHUB_ENV
-          echo "buildpack_repo=$(yj -t < $BUILDPACK_PATH/buildpack.toml | jq -r .metadata.release.image.repository)" >> $GITHUB_ENV
-          echo "buildpack_file=heroku_go.cnb" >> $GITHUB_ENV
-
-      - id: package-buildpack
-        name: "Package buildpack"
-        run: pack buildpack package --path "${{ env.buildpack_path }}" --format file "${{ env.buildpack_file}}"
-
-      - id: dockerhub-login
-        name: "Login to Docker Hub"
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - id: publish-image
-        name: "Publish buildpack to image registry"
-        run: pack buildpack package --path "${{ env.buildpack_path }}" --publish "${{ env.buildpack_repo }}:${{ env.buildpack_version }}"
-
-      - id: image-digest
-        name: "Calculate buildpack image digest"
-        run: |
-          echo "buildpack_digest=$(crane digest ${{ env.buildpack_repo }}:${{ env.buildpack_version }})" >> $GITHUB_ENV
-
-      - id: add-registry-entry
-        name: "Request Buildpack Registry Entry"
-        uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.0
-        with:
-          token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}
-          id: ${{ env.buildpack_id }}
-          version: ${{ env.buildpack_version }}
-          address: ${{ env.buildpack_repo }}@${{ env.buildpack_digest }}
-
-      - id: create_release
-        name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.buildpack_id }}_${{ env.buildpack_version }}
-          release_name: ${{ env.buildpack_id }} ${{ env.buildpack_version }}
-          body: |
-            See the [CHANGELOG](./CHANGELOG.md) for details.
-          draft: false
-          prerelease: false
-
-      - id: upload_package
-        name: Upload buildpackage to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.buildpack_file }}
-          tag: ${{ env.buildpack_id }}_${{ env.buildpack_version }}
-          overwrite: true
+  update-builder:
+    name: Update Builder
+    needs: [ detect, publish-docker, publish-cnb, publish-github ]
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-update-builder.yml@main
+    with:
+      app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+      buildpack_version: ${{ needs.detect.outputs.version }}
+    secrets:
+      app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,33 @@
 # Changelog
-
-All notable changes to this project will be documented in this file.
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.1.6] - 2023-06-28
-
-- No changes
-
-## [0.1.5] - 2023-06-27
+## [0.1.5] 2023/06/27
 
 - Added go1.19.10, go1.20.5.
 - Update to CNB Buildpack API version 0.9. ([#101](https://github.com/heroku/buildpacks-go/pull/101))
 
-## [0.1.4] - 2023-05-09
+## [0.1.4] 2023/05/09
 
 - Added go1.19.9, go1.20.4.
 
-## [0.1.3] - 2023-04-11
+## [0.1.3] 2023/04/11
 
 - Added go1.19.8, go1.20.3.
 - Added go1.19.6, go1.19.7, go1.20.1, go1.20.2.
 
-## [0.1.2] - 2023-02-06
+## [0.1.2] 2023/02/06
 
 - Added go1.20
 
-## [0.1.1] - 2023-01-23
+## [0.1.1] 2023/01/23
 
 - Added go1.19.5, go1.19.4, go1.19.3, go1.19.2, go1.19.1, go1.19
 - Added go1.18.10, go1.18.9, go1.18.7, go1.18.6, go1.18.5, go1.18.4
 - Added go1.17.13, go1.17.12
 
-## [0.1.0] - 2022-12-01
+## [0.1.0] 2022/12/01
 
 - Initial implementation using libcnb.rs ([#1](https://github.com/heroku/buildpacks-go/pull/1))
-
-[unreleased]: https://github.com/heroku/buildpacks-go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,42 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.1.5] 2023/06/27
+## [0.1.6] - 2023-06-28
+
+- No changes
+
+## [0.1.5] - 2023-06-27
 
 - Added go1.19.10, go1.20.5.
 - Update to CNB Buildpack API version 0.9. ([#101](https://github.com/heroku/buildpacks-go/pull/101))
 
-## [0.1.4] 2023/05/09
+## [0.1.4] - 2023-05-09
 
 - Added go1.19.9, go1.20.4.
 
-## [0.1.3] 2023/04/11
+## [0.1.3] - 2023-04-11
 
 - Added go1.19.8, go1.20.3.
 - Added go1.19.6, go1.19.7, go1.20.1, go1.20.2.
 
-## [0.1.2] 2023/02/06
+## [0.1.2] - 2023-02-06
 
 - Added go1.20
 
-## [0.1.1] 2023/01/23
+## [0.1.1] - 2023-01-23
 
 - Added go1.19.5, go1.19.4, go1.19.3, go1.19.2, go1.19.1, go1.19
 - Added go1.18.10, go1.18.9, go1.18.7, go1.18.6, go1.18.5, go1.18.4
 - Added go1.17.13, go1.17.12
 
-## [0.1.0] 2022/12/01
+## [0.1.0] - 2022-12-01
 
 - Initial implementation using libcnb.rs ([#1](https://github.com/heroku/buildpacks-go/pull/1))
+
+[unreleased]: https://github.com/heroku/buildpacks-go

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.9"
 
 [buildpack]
 id = "heroku/go"
-version = "0.1.6"
+version = "0.1.5"
 name = "Heroku Go"
 homepage = "https://github.com/heroku/buildpacks-go"
 keywords = ["go", "golang", "heroku"]

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -18,8 +18,6 @@ id = "heroku-20"
 id = "heroku-22"
 
 [metadata]
-
 [metadata.release]
-
-[metadata.release.image]
+[metadata.release.docker]
 repository = "docker.io/heroku/buildpack-go"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.9"
 
 [buildpack]
 id = "heroku/go"
-version = "0.1.5"
+version = "0.1.6"
 name = "Heroku Go"
 homepage = "https://github.com/heroku/buildpacks-go"
 keywords = ["go", "golang", "heroku"]


### PR DESCRIPTION
This sets up the release automation scripts from [languages-github-actions](https://github.com/heroku/languages-github-actions) for the Go buildpack.

Also in this PR:
* adds the target Docker repository to `buildpack.toml` to align with the metadata used by other Heroku buildpacks

[W-13658753](https://gus.lightning.force.com/a07EE00001UktfwYAB)