### PR TITLE
Update inventory automation with github app and auto merge

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -35,7 +35,7 @@ jobs:
           delimiter="$(openssl rand -hex 8)"
           {
             echo "msg<<${delimiter}"
-            cargo run --bin diff_versions "${{ inputs.distribution }}" "${{ inputs.buildpack_path }}/inventory.toml"
+            cargo run --bin diff_inventory inventory.toml
             echo "${delimiter}"
           } >> $GITHUB_OUTPUT
 

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -14,25 +14,52 @@ jobs:
     name: Update Go Inventory
     runs-on: pub-hk-ubuntu-22.04-small
     steps:
+      - uses: heroku/use-app-token-action@main
+        id: generate-token
+        with:
+          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v3
+
       - id: install-rust-toolchain
         name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - id: set-diff-msg
-        name: Set Diff Message
-        run: echo "DIFF_MSG=$(cargo run --bin diff_inventory inventory.toml)" >> $GITHUB_OUTPUT
+
+      - name: Set Diff Message
+        id: set-diff-msg
+        run: |
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "msg<<${delimiter}"
+            cargo run --bin diff_versions "${{ inputs.distribution }}" "${{ inputs.buildpack_path }}/inventory.toml"
+            echo "${delimiter}"
+          } >> $GITHUB_OUTPUT
+
       - name: Rebuild Inventory
         run: "cargo run --bin update_inventory inventory.toml"
+
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.DIFF_MSG }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
+
       - name: Create Pull Request
+        id: pr
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ steps.generate-token.outputs.app_token }}
           title: "Update Go Inventory"
-          commit-message: "Update Inventory for heroku/go\n\n${{ steps.set-diff-msg.outputs.DIFF_MSG }}"
+          commit-message: "Update Inventory for heroku/go\n\n${{ steps.set-diff-msg.outputs.msg }}"
+          committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
           branch: update-go-inventory
           labels: "automation"
-          body: "Automated pull-request to update heroku/go inventory:\n\n${{ steps.set-diff-msg.outputs.DIFF_MSG }}"
+          body: "Automated pull-request to update heroku/go inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
+
+      - name: Configure PR
+        if: steps.pr.outputs.pull-request-operation == 'created'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+        run: gh pr merge --squash --auto "${{ steps.pr.outputs.pull-request-number }}"


### PR DESCRIPTION
This brings in some of the latest improvements from the Node.js CNB inventory automation. Namely: Uses the linguist GitHub App, supports multiline diff messages, and sets the inventory update PR to auto-merge.

This is needed since our inventory automation is no longer able to create PRs. Recent automation exits with this message: `Error: GitHub Actions is not permitted to create or approve pull requests.`. [Example](https://github.com/heroku/buildpacks-go/actions/runs/6227212544/job/16901352387).