### PR TITLE
Switch tests from `heroku/buildpacks:20` to `heroku/builder:20`

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -50,7 +50,7 @@ fn test_basic_http_116(builder: &str) {
 #[test]
 #[ignore = "integration test"]
 fn basic_http_116_20() {
-    test_basic_http_116("heroku/buildpacks:20");
+    test_basic_http_116("heroku/builder:20");
 }
 #[test]
 #[ignore = "integration test"]
@@ -73,7 +73,7 @@ fn test_vendor_gorilla_117(builder: &str) {
 #[test]
 #[ignore = "integration test"]
 fn vendor_gorilla_117_20() {
-    test_vendor_gorilla_117("heroku/buildpacks:20");
+    test_vendor_gorilla_117("heroku/builder:20");
 }
 #[test]
 #[ignore = "integration test"]
@@ -96,7 +96,7 @@ fn test_modules_gin_121(builder: &str) {
 #[test]
 #[ignore = "integration test"]
 fn modules_gin_121_20() {
-    test_modules_gin_121("heroku/buildpacks:20");
+    test_modules_gin_121("heroku/builder:20");
 }
 #[test]
 #[ignore = "integration test"]
@@ -120,7 +120,7 @@ fn test_worker_http_118(builder: &str) {
 #[test]
 #[ignore = "integration test"]
 fn worker_http_118_20() {
-    test_worker_http_118("heroku/buildpacks:20");
+    test_worker_http_118("heroku/builder:20");
 }
 #[test]
 #[ignore = "integration test"]
@@ -142,7 +142,7 @@ fn test_basic_http_119(builder: &str) {
 #[test]
 #[ignore = "integration test"]
 fn basic_http_119_20() {
-    test_basic_http_119("heroku/buildpacks:20");
+    test_basic_http_119("heroku/builder:20");
 }
 #[test]
 #[ignore = "integration test"]
@@ -165,7 +165,7 @@ fn test_vendor_fasthttp_120(builder: &str) {
 #[test]
 #[ignore = "integration test"]
 fn vendor_fasthttp_120_20() {
-    test_vendor_fasthttp_120("heroku/buildpacks:20");
+    test_vendor_fasthttp_120("heroku/builder:20");
 }
 #[test]
 #[ignore = "integration test"]


### PR DESCRIPTION
Since the `heroku/buildpacks:20` image is about to be deprecated, and has been replaced by the newly added `heroku/builder:20` for those that need to use a Heroku-20 based builder.

The build and run images used by `heroku/builder:20` are the same as those used by `heroku/buildpacks:20` - the only differences between the builders are the included buildpacks (which is somewhat irrelevant for these integration tests, since the buildpack under test will be injected instead).

The smoke tests in the `heroku/builder` GitHub repo are still testing against all image variants (until such time as we make the legacy images error with an EOL message), so we still have test coverage against them.

See:
https://github.com/heroku/builder/pull/394
https://salesforce.quip.com/0JtbAYiWZYk6

GUS-W-14186015.