### PR TITLE
Make the changelog conform to the keepachangelog.com style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,48 +9,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.9] - 2023-09-18
 
-- Added go1.19.13, go1.20.8, go1.21.1.
+### Added
+
+- Added go1.19.13, go1.20.8, go1.21.1. ([#154](https://github.com/heroku/buildpacks-go/pull/154))
 
 ## [0.1.8] - 2023-08-15
 
-- Ensure $GOROOT/go.env is installed.
-- Added go1.21.0.
+### Added
+
+- Added go1.21.0. ([#136](https://github.com/heroku/buildpacks-go/pull/136))
+
+### Fixed
+
+- The `$GOROOT/go.env` file is now correctly installed. ([#137](https://github.com/heroku/buildpacks-go/pull/137))
 
 ## [0.1.7] - 2023-08-07
 
-- Added go1.19.12, go1.20.7, go1.21rc4.
+### Added
+
+- Added go1.19.12, go1.20.7, go1.21rc4. ([#132](https://github.com/heroku/buildpacks-go/pull/132))
 
 ## [0.1.6] - 2023-08-01
 
-- Added go1.19.11, go1.20.6, go1.21rc1, go1.21rc2, go1.21rc3.
+### Added
+
+- Added go1.19.11, go1.20.6, go1.21rc1, go1.21rc2, go1.21rc3. ([#105](https://github.com/heroku/buildpacks-go/pull/105))
 
 ## [0.1.5] - 2023-06-27
 
-- Added go1.19.10, go1.20.5.
-- Update to CNB Buildpack API version 0.9. ([#101](https://github.com/heroku/buildpacks-go/pull/101))
+### Added
+
+- Added go1.19.10, go1.20.5. ([#102](https://github.com/heroku/buildpacks-go/pull/102))
+
+### Changed
+
+- The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#101](https://github.com/heroku/buildpacks-go/pull/101))
 
 ## [0.1.4] - 2023-05-09
 
-- Added go1.19.9, go1.20.4.
+### Added
+
+- Added go1.19.9, go1.20.4. ([#92](https://github.com/heroku/buildpacks-go/pull/92))
 
 ## [0.1.3] - 2023-04-11
 
-- Added go1.19.8, go1.20.3.
-- Added go1.19.6, go1.19.7, go1.20.1, go1.20.2.
+### Added
+
+- Added go1.19.8, go1.20.3. ([#83](https://github.com/heroku/buildpacks-go/pull/83))
+- Added go1.19.6, go1.19.7, go1.20.1, go1.20.2. ([#75](https://github.com/heroku/buildpacks-go/pull/75))
 
 ## [0.1.2] - 2023-02-06
 
-- Added go1.20
+### Added
+
+- Added go1.20. ([#65](https://github.com/heroku/buildpacks-go/pull/65))
 
 ## [0.1.1] - 2023-01-23
 
-- Added go1.19.5, go1.19.4, go1.19.3, go1.19.2, go1.19.1, go1.19
-- Added go1.18.10, go1.18.9, go1.18.7, go1.18.6, go1.18.5, go1.18.4
-- Added go1.17.13, go1.17.12
+### Added
+
+- Added go1.19.5, go1.19.4, go1.19.3, go1.19.2, go1.19.1, go1.19. ([#57](https://github.com/heroku/buildpacks-go/pull/57))
+- Added go1.18.10, go1.18.9, go1.18.7, go1.18.6, go1.18.5, go1.18.4. ([#57](https://github.com/heroku/buildpacks-go/pull/57))
+- Added go1.17.13, go1.17.12. ([#57](https://github.com/heroku/buildpacks-go/pull/57))
 
 ## [0.1.0] - 2022-12-01
 
-- Initial implementation using libcnb.rs ([#1](https://github.com/heroku/buildpacks-go/pull/1))
+### Added
+
+- Initial implementation using libcnb.rs. ([#1](https://github.com/heroku/buildpacks-go/pull/1))
 
 [unreleased]: https://github.com/heroku/buildpacks-go/compare/v0.1.9...HEAD
 [0.1.9]: https://github.com/heroku/buildpacks-go/compare/v0.1.8...v0.1.9


### PR DESCRIPTION
The changelog intro says it conforms to the https://keepachangelog.com style, but previously the content actually did not. Now it does match that style, making it consistent with our other CNBs.

See:
https://keepachangelog.com/en/1.1.0/

I've also added links to the GitHub PRs for each entry. Whilst adding these is extra work for each PR, I feel it's worthwhile for end-users -- I very much find it useful when projects we use do the same.

GUS-W-14283439.
