### PR TITLE
Don't add the `automation` label to inventory PRs

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -55,7 +55,6 @@ jobs:
           committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
           author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
           branch: update-go-inventory
-          labels: "automation"
           body: "Automated pull-request to update heroku/go inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
 
       - name: Configure PR


### PR DESCRIPTION
For the same reasons as:
https://github.com/heroku/languages-github-actions/pull/109

GUS-W-14283772.