### PR TITLE
Add buildpack description to buildpack.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added buildpack description to metadata used by CNB registry. ([#178](https://github.com/heroku/buildpack-go/pull/178))
+
 ## [0.1.10] - 2023-10-12
 
 ### Added

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,6 +5,7 @@ id = "heroku/go"
 version = "0.1.10"
 name = "Heroku Go"
 homepage = "https://github.com/heroku/buildpacks-go"
+description = "Heroku's buildpack for Go applications."
 keywords = ["go", "golang", "heroku"]
 clear-env = true
 
@@ -17,7 +18,5 @@ id = "heroku-20"
 [[stacks]]
 id = "heroku-22"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-go"
+image = { repository = "docker.io/heroku/buildpack-go" }


### PR DESCRIPTION
Adds the buildpack `description` to `buildpack.toml` with a style matching that discussed in:
https://github.com/heroku/cnb-builder-images/issues/408

The `description` field is displayed on the CNB registry's page for the buildpack.

In addition, I've cleaned up the `[metadata]` table/subtables to match the more concise style used by the Procfile and Python CNBs.

GUS-W-14121598.