### PR TITLE
Switch to Cargo.toml based lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,15 @@ version = "0.0.0"
 description = "Heroku Go Cloud Native Buildpack"
 edition = "2021"
 publish = false
-rust-version = "1.66"
+rust-version = "1.74"
+
+[lints.rust]
+# TODO: Enable this lint once the lib target is split out to a shared code crate,
+# which will reduce the false positives and make using this lint viable.
+# unused_crate_dependencies = "warn"
+
+[lints.clippy]
+pedantic = "warn"
 
 [dependencies]
 flate2 = { version = "1", default-features = false, features = ["zlib"] }

--- a/src/bin/diff_inventory.rs
+++ b/src/bin/diff_inventory.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 use heroku_go_buildpack::inv::{list_github_go_versions, Artifact, Inventory};
 use std::collections::HashSet;
 

--- a/src/bin/update_inventory.rs
+++ b/src/bin/update_inventory.rs
@@ -1,6 +1,3 @@
-#![warn(clippy::pedantic)]
-#![allow(clippy::module_name_repetitions)]
-
 use heroku_go_buildpack::inv::{list_github_go_versions, Artifact, Inventory};
 use std::collections::HashSet;
 use std::{env, fs, process};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,2 @@
-#![warn(clippy::pedantic)]
 pub mod inv;
 pub mod vrs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#![warn(clippy::pedantic)]
-#![warn(clippy::cargo)]
-
 mod cfg;
 mod cmd;
 mod layers;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 use libcnb_test::{assert_contains, assert_not_contains, BuildConfig, ContainerConfig, TestRunner};
 use std::time::Duration;
 


### PR DESCRIPTION
As of the Cargo included in Rust 1.74, lints can now be configured in `Cargo.toml` across whole crates/workspaces:
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section

This reduces the boilerplate, and the chance that we forget to enable lints in some targets.

Since this feature requires Rust 1.74, the MSRV has also been bumped (however, libcnb 0.16.0 already requires Rust 1.74, so in practice this is a no-op).

GUS-W-14523792.