### PR TITLE
Enable additional rustc and Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,16 @@ publish = false
 rust-version = "1.74"
 
 [lints.rust]
+unreachable_pub = "warn"
+unsafe_code = "warn"
 # TODO: Enable this lint once the lib target is split out to a shared code crate,
 # which will reduce the false positives and make using this lint viable.
 # unused_crate_dependencies = "warn"
 
 [lints.clippy]
+panic_in_result_fn = "warn"
 pedantic = "warn"
+unwrap_used = "warn"
 
 [dependencies]
 flate2 = { version = "1", default-features = false, features = ["zlib"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -5,8 +5,8 @@ use std::path;
 
 /// Represents buildpack configuration found in a project's `go.mod`.
 pub(crate) struct GoModConfig {
-    pub packages: Option<Vec<String>>,
-    pub version: Option<Requirement>,
+    pub(crate) packages: Option<Vec<String>>,
+    pub(crate) version: Option<Requirement>,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/inv.rs
+++ b/src/inv.rs
@@ -3,12 +3,11 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use toml;
 
-pub const GITHUB_API_URL: &str = "https://api.github.com";
-pub const GO_REPO_NAME: &str = "golang/go";
-pub const GO_HOST_URL: &str = "https://dl.google.com/go";
-pub const GO_MIRROR_URL: &str = "https://heroku-golang-prod.s3.us-east-1.amazonaws.com";
-pub const REGION: &str = "us-east-1";
-pub const ARCH: &str = "linux-amd64";
+const GITHUB_API_URL: &str = "https://api.github.com";
+const GO_REPO_NAME: &str = "golang/go";
+const GO_HOST_URL: &str = "https://dl.google.com/go";
+const GO_MIRROR_URL: &str = "https://heroku-golang-prod.s3.us-east-1.amazonaws.com";
+const ARCH: &str = "linux-amd64";
 
 /// Represents a collection of known go release artifacts.
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/layers/build.rs
+++ b/src/layers/build.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 /// A layer for go incremental build cache artifacts
 pub(crate) struct BuildLayer {
-    pub go_version: String,
+    pub(crate) go_version: String,
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq)]

--- a/src/layers/dist.rs
+++ b/src/layers/dist.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 /// A layer that downloads and installs the Go distribution artifacts
 pub(crate) struct DistLayer {
-    pub artifact: Artifact,
+    pub(crate) artifact: Artifact,
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use std::path::Path;
 
 const INVENTORY: &str = include_str!("../inventory.toml");
 
-pub(crate) struct GoBuildpack;
+struct GoBuildpack;
 
 impl Buildpack for GoBuildpack {
     type Platform = GenericPlatform;
@@ -168,7 +168,7 @@ impl Buildpack for GoBuildpack {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum GoBuildpackError {
+enum GoBuildpackError {
     #[error("{0}")]
     BuildLayer(#[from] BuildLayerError),
     #[error("Couldn't run `go build`: {0}")]

--- a/src/tgz.rs
+++ b/src/tgz.rs
@@ -86,13 +86,13 @@ struct DigestingReader<R: Read, H: sha2::Digest> {
 }
 
 impl<R: Read, H: sha2::Digest> DigestingReader<R, H> {
-    pub fn new(reader: R, hasher: H) -> DigestingReader<R, H> {
+    pub(crate) fn new(reader: R, hasher: H) -> DigestingReader<R, H> {
         DigestingReader {
             r: reader,
             h: hasher,
         }
     }
-    pub fn finalize(self) -> GenericArray<u8, <H as OutputSizeUser>::OutputSize> {
+    pub(crate) fn finalize(self) -> GenericArray<u8, <H as OutputSizeUser>::OutputSize> {
         self.h.finalize()
     }
 }


### PR DESCRIPTION
Enables some off-by-default lints that we already use in the `libcnb.rs` repository.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-code
https://rust-lang.github.io/rust-clippy/master/index.html#/panic_in_result_fn
https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_used

GUS-W-14523792.