### PR TITLE
Fix changelog generation during inventory updates

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -43,7 +43,7 @@ jobs:
         run: "cargo run --bin update_inventory inventory.toml"
 
       - name: Update Changelog
-        run: echo "${{ steps.set-diff-msg.outputs.DIFF_MSG }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
 
       - name: Create Pull Request
         id: pr


### PR DESCRIPTION
We were using an incorrect output value from a previous step. It looks like the output value changed in https://github.com/heroku/buildpacks-go/pull/156, but didn't get referenced correctly in the changelog step.