### PR TITLE
Simplify Cargo metadata for `publish = false` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,8 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.0"
 rust-version = "1.75"
 edition = "2021"
-publish = false
 
 [workspace.lints.rust]
 unreachable_pub = "warn"

--- a/buildpacks/go/Cargo.toml
+++ b/buildpacks/go/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "heroku-go-buildpack"
-description = "Heroku Go Cloud Native Buildpack"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/common/go-utils/Cargo.toml
+++ b/common/go-utils/Cargo.toml
@@ -1,7 +1,5 @@
 [package]
 name = "heroku-go-utils"
-description = "Libs and bins for the Heroku Go Buildpack"
-version.workspace = true
 rust-version.workspace = true
 edition.workspace = true
 


### PR DESCRIPTION
As of Cargo 1.75 the `version` property in `Cargo.toml` is now optional, and if omitted is the same as having specified `version = "0.0.0"` and `publish = false`:
https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28
https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field

Therefore for crates that we do not publish, we can now remove both the `version` and `publish` properties, avoiding the need for the fake `0.0.0` version that differs from the actual buildpack version in `buildpack.toml`.

In addition, the `Cargo.toml` `description` property has been removed, since:
- it's unused unless the crate is published
- it duplicates the description in `buildpack.toml` / the README etc

GUS-W-14821120.