### PR TITLE
Enable `unused_crate_dependencies` lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,6 @@ dependencies = [
  "libcnb-test",
  "libherokubuildpack",
  "serde",
- "serde_json",
  "sha2",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,7 @@ edition = "2021"
 [workspace.lints.rust]
 unreachable_pub = "warn"
 unsafe_code = "warn"
-# TODO: Enable this lint once the heroku-go-utils binary targets are split into
-# their own crates. This should reduce false positives and make this lint viable.
-# unused_crate_dependencies = "warn"
+unused_crate_dependencies = "warn"
 
 [workspace.lints.clippy]
 panic_in_result_fn = "warn"

--- a/buildpacks/go/Cargo.toml
+++ b/buildpacks/go/Cargo.toml
@@ -14,13 +14,12 @@ flate2 = { version = "1", default-features = false, features = ["zlib"] }
 libcnb = { version = "=0.17.0", features = ["trace"] }
 libherokubuildpack = { version = "=0.17.0", default-features = false, features = ["log"] }
 serde = "1"
-serde_json = "1"
 sha2 = "0.10"
 tar = { version = "0.4", default-features = false }
-tempfile = "3"
 thiserror = "1"
 toml = "0.8"
 ureq = { version = "2", features = ["json"] }
 
 [dev-dependencies]
 libcnb-test = "=0.17.0"
+tempfile = "3"

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -23,6 +23,9 @@ use libherokubuildpack::log::{log_error, log_header, log_info};
 use std::env;
 use std::path::Path;
 
+#[cfg(test)]
+use libcnb_test as _;
+
 const INVENTORY: &str = include_str!("../inventory.toml");
 
 struct GoBuildpack;

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -1,3 +1,6 @@
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
+
 use libcnb_test::{assert_contains, assert_not_contains, BuildConfig, ContainerConfig, TestRunner};
 use std::time::Duration;
 

--- a/common/go-utils/src/bin/diff_inventory.rs
+++ b/common/go-utils/src/bin/diff_inventory.rs
@@ -1,3 +1,6 @@
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
+
 use heroku_go_utils::inv::{list_github_go_versions, Artifact, Inventory};
 use std::collections::HashSet;
 

--- a/common/go-utils/src/bin/update_inventory.rs
+++ b/common/go-utils/src/bin/update_inventory.rs
@@ -1,3 +1,6 @@
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
+
 use heroku_go_utils::inv::{list_github_go_versions, Artifact, Inventory};
 use std::collections::HashSet;
 use std::{env, fs, process};


### PR DESCRIPTION
For parity with our other CNBs.

This lint wasn't enabled previously, due to many false positives from the binary utils having previously been part of the main crate - however, they've since been split out into the `go-utils` crate in this repo.

Enabling this lint found some unused/mis-categorised deps, which have now been fixed.