### PR TITLE
Add CONTRIBUTING.md guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ first instead.
 ### Dependencies
 
 This buildpack relies on [heroku/libcnb.rs](libcnb) to compile buildpacks. All
-[libcnb.rs dependencies](https://https://github.com/heroku/libcnb.rs#development-environment-setup)
+[libcnb.rs dependencies](https://github.com/heroku/libcnb.rs#development-environment-setup)
 will need to be setup prior to building or testing this buildpack.
 
 ### Building

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing Guide for Heroku Cloud Native Buildpacks
+
+This page lists the operational governance model of this project, as well as
+the recommendations and requirements for how to best contribute to Heroku
+Cloud Native Buildpacks. We strive to obey these as best as possible. As
+always, thanks for contributing.
+
+## Governance Model: Salesforce Sponsored
+
+The intent and goal of open sourcing this project is to increase the contributor
+and user base. However, only Salesforce employees will be given `admin` rights
+and will be the final arbitrars of what contributions are accepted or not.
+
+## Getting started
+
+Please feel free to join the
+[Heroku Cloud Native Buildpacks discussions](https://github.com/heroku/buildpacks/discussions).
+You may also wish to take a look at
+[Heroku's product roadmap](https://github.com/heroku/roadmap) to see where are headed.
+
+## Ideas and Feedback
+
+Please use
+[Heroku Cloud Native Buildpacks discussions](https://github.com/heroku/buildpacks/discussions)
+to provide feedback, request enhancements, or discuss ideas.
+
+## Issues, Feature Requests, and Bug Reports
+
+Issues, feature requests, and bug reports are tracked via [GitHub issues on
+this repository](https://github.com/heroku/buildpacks-go/issues). If you find
+an issue and/or bug, please search the issues, and if it isn't already tracked,
+create a new issue.
+
+## Fixes, Improvements, and Patches
+
+Fixes, improvements, and patches all happen via [GitHub Pull Requests on this
+repository](https://github.com/heroku/buildpacks-go/pulls). If you'd like to
+improve the tests, you want to make the documentation clearer, you have an
+alternative implementation of something that may have advantages over the way
+its currently done, or you have any other change, we would be happy to hear
+about it. For trivial changes, send a pull request. For non-trivial changes, consider
+[opening an issue](#issues-feature-requests-and-bug-reports) to discuss it
+first instead.
+
+## Development
+
+### Dependencies
+
+This buildpack relies on [heroku/libcnb.rs](libcnb) to compile buildpacks. All
+[libcnb.rs dependencies](https://https://github.com/heroku/libcnb.rs#development-environment-setup)
+will need to be setup prior to building or testing this buildpack.
+
+### Building
+
+1. Run `cargo check` to download dependencies and ensure there are no
+   compilation issues.
+1. Build the buildpack with `cargo libcnb package`.
+1. Use the buildpack to build an app: `pack build go-example --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_go --path /path/to/go-app`
+
+### Testing
+
+- `cargo test` performs Rust unit tests.
+- `cargo test -- --ignored` performs all integration tests.
+
+## Code of Conduct
+Please follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+By contributing your code, you agree to license your contribution under the
+terms of our project [LICENSE](LICENSE) and to sign the
+[Salesforce CLA](https://cla.salesforce.com/sign-cla).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ binaries.
 
 ## License
 
-Licensed under the BSD 3-clause License. See [LICENSE](./LICENSE) file.
+Licensed under the BSD 3-clause License. See [LICENSE](./LICENSE.txt) file.
 
 [classic]: https://github.com/heroku/heroku-buildpack-go
 [cnb]: https://buildpacks.io/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This buildpack does not support 3rd party dependency managers such as `dep`,
 ### Go Version
 
 This buildpack will read the Go version from the `go` line in `go.mod`. This
-is likely correct for most apps, but a different version may be selected using 
+is likely correct for most apps, but a different version may be selected using
 the `// +heroku goVersion [{constraint}]{version}` build directive in `go.mod`,
 if required.
 
@@ -79,29 +79,6 @@ binaries.
 ```
 // +heroku install example.com/example-server example.com/example-worker
 ```
-
-## Development
-
-### Dependencies
-
-This buildpack relies on [heroku/libcnb.rs](libcnb) to compile buildpacks. All
-[libcnb.rs dependencies](https://https://github.com/heroku/libcnb.rs#development-environment-setup) will need to be setup prior to building or testing this buildpack.
-
-### Building
-
-1. Run `cargo check` to download dependencies and ensure there are no
-   compilation issues.
-1. Build the buildpack with `cargo libcnb package`.
-1. Use the buildpack to build an app: `pack build go-example --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_go --path /path/to/go-app`
-
-### Testing
-
-- `cargo test` performs Rust unit tests.
-- `cargo test -- --ignored` performs all integration tests.
-
-## Releasing
-
-[Deploy Cloud Native Buildpacks](https://github.com/heroku/languages-team/blob/main/languages/cnb/deploy.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ binaries.
 // +heroku install example.com/example-server example.com/example-worker
 ```
 
+## Contributing
+
+Issues and pull requests are welcome. See our [contributing guidelines](./CONTRIBUTING.md) if you would like to help.
+
 ## License
 
 Licensed under the BSD 3-clause License. See [LICENSE](./LICENSE.txt) file.


### PR DESCRIPTION
This adds a modified version of the [`CONTRIBUTING.md` guide from the Salesforce OSS template](https://github.com/salesforce/oss-template/blob/main/CONTRIBUTING.md). It's fairly similar to the guide added here: https://github.com/heroku/buildpacks/pull/1.