### PR TITLE
Support arm64

### DIFF
--- a/buildpacks/go/CHANGELOG.md
+++ b/buildpacks/go/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added linux aarch64 artifacts for >= go1.8.5. ([#230](https://github.com/heroku/buildpacks-go/pull/230))
+- Added linux/arm64 buildpack target. ([#233](https://github.com/heroku/buildpacks-go/pull/233))
 
 ## [0.2.0] - 2024-03-06
 

--- a/buildpacks/go/buildpack.toml
+++ b/buildpacks/go/buildpack.toml
@@ -14,6 +14,10 @@ type = "BSD-3-Clause"
 
 [[targets]]
 os = "linux"
+arch = "arm64"
+
+[[targets]]
+os = "linux"
 arch = "amd64"
 
 [metadata.release]


### PR DESCRIPTION
This PR adds the linux/arm64 target in `buildpack.toml`.

For testing the buildpack, an arm64 compatible builder can be created locally (using the newly released `heroku-24` base images (tested on an m1 Mac with Docker's `containerd` feature enabled), and a basic builder configuration file) - e.g. something like this:

`builder-24/builder.toml`:
```toml
description = "Heroku-24 (Ubuntu 24.04) builder sans buildpacks"

[stack]
id = "heroku-24"
build-image = "heroku/heroku:24-build.nightly"
run-image = "heroku/heroku:24.nightly"

[lifecycle]
version = "0.19.0"
```

Create the builder:

    pack builder create heroku/builder:24 --config ./builder-24/builder.toml

Compile and package the CNBs:

    cargo libcnb package

    cargo libcnb package --target aarch64-unknown-linux-musl

To test that the `x86_64` version still work as intended, we need to use the old builder (as`heroku/builder:24` won't work for multi-arch locally):
```
pack build go-amd64-app \
--buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_go \
--path buildpacks/go/tests/fixtures/basic_http_122 --builder heroku/builder:22
```

To test `aarch64`:

```
pack build go-arm64-app \
--buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_go \
--path buildpacks/go/tests/fixtures/basic_http_122 --builder heroku/builder:24
```

Running the commands twice should reuse cached layers as usual. Another app can be used to verify cache invalidation, e.g.:

```
pack build go-arm64-app \
--buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_go \
--path buildpacks/go/tests/fixtures/basic_http_119 --builder heroku/builder:24
```

This can also be tested with an integration test in `buildpacks/go/tests/integration_tests.rs` (and a similar test should be added when `heroku/builder:24` is available in the registry):

```rust
#[test]
#[ignore = "integration test"]
fn test_go_arm64() {
    TestRunner::default().build(
        BuildConfig::new("heroku/builder:24", "tests/fixtures/basic_http_116")
            .target_triple("aarch64-unknown-linux-musl"),
        |ctx| {
            assert_contains!(
                ctx.pack_stdout,
                "Installing go1.16.15 (linux-aarch64) from https://go.dev/dl/go1.16.15.linux-arm64.tar.gz",
            );
        },
    );
}
```