### PR TITLE
Prefer artifact over version in buildpack layers

### DIFF
--- a/buildpacks/go/src/layers/dist.rs
+++ b/buildpacks/go/src/layers/dist.rs
@@ -83,7 +83,7 @@ impl Layer for DistLayer {
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
         if layer_data.content_metadata.metadata == DistLayerMetadata::current(self) {
-            log_info(format!("Reusing Go {}", self.artifact));
+            log_info(format!("Reusing {}", self.artifact));
             Ok(ExistingLayerStrategy::Keep)
         } else {
             Ok(ExistingLayerStrategy::Recreate)

--- a/buildpacks/go/src/layers/dist.rs
+++ b/buildpacks/go/src/layers/dist.rs
@@ -17,7 +17,7 @@ pub(crate) struct DistLayer {
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub(crate) struct DistLayerMetadata {
     layer_version: String,
-    go_version: String,
+    artifact: Artifact,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -45,7 +45,10 @@ impl Layer for DistLayer {
         _ctx: &BuildContext<Self::Buildpack>,
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, GoBuildpackError> {
-        log_info(format!("Installing Go {}", self.artifact.semantic_version));
+        log_info(format!(
+            "Installing Go {} from {}",
+            self.artifact.semantic_version, self.artifact.url
+        ));
         tgz::fetch_strip_filter_extract_verify(
             self.artifact.url.clone(),
             "go",
@@ -80,7 +83,7 @@ impl Layer for DistLayer {
         layer_data: &LayerData<Self::Metadata>,
     ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
         if layer_data.content_metadata.metadata == DistLayerMetadata::current(self) {
-            log_info(format!("Reusing Go {}", self.artifact.semantic_version));
+            log_info(format!("Reusing Go {}", self.artifact));
             Ok(ExistingLayerStrategy::Keep)
         } else {
             Ok(ExistingLayerStrategy::Recreate)
@@ -91,7 +94,7 @@ impl Layer for DistLayer {
 impl DistLayerMetadata {
     fn current(layer: &DistLayer) -> Self {
         DistLayerMetadata {
-            go_version: layer.artifact.go_version.clone(),
+            artifact: layer.artifact.clone(),
             layer_version: String::from(LAYER_VERSION),
         }
     }

--- a/buildpacks/go/src/layers/dist.rs
+++ b/buildpacks/go/src/layers/dist.rs
@@ -46,8 +46,8 @@ impl Layer for DistLayer {
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, GoBuildpackError> {
         log_info(format!(
-            "Installing Go {} from {}",
-            self.artifact.semantic_version, self.artifact.url
+            "Installing {} from {}",
+            self.artifact, self.artifact.url
         ));
         tgz::fetch_strip_filter_extract_verify(
             self.artifact.url.clone(),

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -72,10 +72,7 @@ impl Buildpack for GoBuildpack {
         let artifact = inv
             .resolve(&requirement)
             .ok_or(GoBuildpackError::VersionResolution(requirement))?;
-        log_info(format!(
-            "Resolved Go version: {}",
-            artifact.semantic_version
-        ));
+        log_info(format!("Resolved Go version: {artifact}"));
 
         log_header("Installing Go distribution");
         go_env = context

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -113,7 +113,7 @@ impl Buildpack for GoBuildpack {
             .handle_layer(
                 layer_name!("go_build"),
                 BuildLayer {
-                    go_version: artifact.go_version.clone(),
+                    artifact: artifact.clone(),
                 },
             )?
             .env

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -195,3 +195,21 @@ fn basic_http_122_20() {
 fn basic_http_122_22() {
     test_basic_http_122("heroku/builder:22");
 }
+
+#[test]
+#[ignore = "integration test"]
+fn test_go_artifact_caching() {
+    TestRunner::default().build(
+        BuildConfig::new("heroku/builder:22", "tests/fixtures/basic_http_116"),
+        |ctx| {
+            assert_contains!(
+                ctx.pack_stdout,
+                "Installing Go 1.16.15 from https://go.dev/dl/go1.16.15.linux-amd64.tar.gz",
+            );
+            let config = ctx.config.clone();
+            ctx.rebuild(config, |ctx| {
+                assert_contains!(ctx.pack_stdout, "Reusing Go go1.16.15 (linux-x86_64)");
+            });
+        },
+    );
+}

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -43,6 +43,7 @@ fn test_basic_http_116(builder: &str) {
         builder,
         &[
             "Detected Go version requirement: ~1.16.2",
+            "Resolved Go version: go1.16.",
             "Installing go1.16.",
         ],
         &[],

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -43,7 +43,7 @@ fn test_basic_http_116(builder: &str) {
         builder,
         &[
             "Detected Go version requirement: ~1.16.2",
-            "Installing Go 1.16.",
+            "Installing go1.16.",
         ],
         &[],
     );
@@ -65,7 +65,7 @@ fn test_vendor_gorilla_117(builder: &str) {
         builder,
         &[
             "Detected Go version requirement: =1.17.8",
-            "Installing Go 1.17.8",
+            "Installing go1.17.8",
             "Using vendored Go modules",
         ],
         &["downloading github.com/gorilla/mux v1.8.0"],
@@ -88,7 +88,7 @@ fn test_modules_gin_121(builder: &str) {
         builder,
         &[
             "Detected Go version requirement: =1.21",
-            "Installing Go 1.21",
+            "Installing go1.21",
             "downloading github.com/gin-gonic/gin v1.8.1",
         ],
         &[],
@@ -111,7 +111,7 @@ fn test_worker_http_118(builder: &str) {
         builder,
         &[
             "Detected Go version requirement: ~1.18.1",
-            "Installing Go 1.18.",
+            "Installing go1.18.",
             "example.com/worker_http_118/cmd/web",
             "example.com/worker_http_118/cmd/worker",
         ],
@@ -135,7 +135,7 @@ fn test_basic_http_119(builder: &str) {
         builder,
         &[
             "Detected Go version requirement: ~1.19.4",
-            "Installing Go 1.19.",
+            "Installing go1.19.",
         ],
         &[],
     );
@@ -157,7 +157,7 @@ fn test_vendor_fasthttp_120(builder: &str) {
         builder,
         &[
             "Detected Go version requirement: =1.20",
-            "Installing Go 1.20.",
+            "Installing go1.20.",
             "Using vendored Go modules",
         ],
         &["downloading github.com/valyala/fasthttp"],
@@ -180,7 +180,7 @@ fn test_basic_http_122(builder: &str) {
         builder,
         &[
             "Detected Go version requirement: ~1.22.0",
-            "Installing Go 1.22.",
+            "Installing go1.22.",
         ],
         &[],
     );
@@ -204,7 +204,7 @@ fn test_go_artifact_caching() {
         |ctx| {
             assert_contains!(
                 ctx.pack_stdout,
-                "Installing Go 1.16.15 from https://go.dev/dl/go1.16.15.linux-amd64.tar.gz",
+                "Installing go1.16.15 (linux-x86_64) from https://go.dev/dl/go1.16.15.linux-amd64.tar.gz",
             );
             let config = ctx.config.clone();
             ctx.rebuild(config, |ctx| {

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -208,7 +208,7 @@ fn test_go_artifact_caching() {
             );
             let config = ctx.config.clone();
             ctx.rebuild(config, |ctx| {
-                assert_contains!(ctx.pack_stdout, "Reusing Go go1.16.15 (linux-x86_64)");
+                assert_contains!(ctx.pack_stdout, "Reusing go1.16.15 (linux-x86_64)");
             });
         },
     );


### PR DESCRIPTION
Prefer using the full `Artifact` instead of just the `Artifact#go_version`, in buildpack layers. This changes the buildpack output to include more information about the Go artifact (i.e. architecture and os, and where the artifact is downloaded from) - and allow us to add more target architectures (e.g. https://github.com/heroku/buildpacks-go/pull/233) that factor in the target os/arch in addition to the version