### PR TITLE
Make inventory logic generic

### DIFF
--- a/buildpacks/go/src/cfg.rs
+++ b/buildpacks/go/src/cfg.rs
@@ -1,4 +1,4 @@
-use heroku_go_utils::vrs::{GoRequirement, RequirementParseError};
+use heroku_go_utils::vrs::{GoRequirement, RequirementParseError, VersionRequirement};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path;

--- a/buildpacks/go/src/cfg.rs
+++ b/buildpacks/go/src/cfg.rs
@@ -1,4 +1,4 @@
-use heroku_go_utils::vrs::{Requirement, RequirementParseError};
+use heroku_go_utils::vrs::{GoRequirement, RequirementParseError};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path;
@@ -6,7 +6,7 @@ use std::path;
 /// Represents buildpack configuration found in a project's `go.mod`.
 pub(crate) struct GoModConfig {
     pub(crate) packages: Option<Vec<String>>,
-    pub(crate) version: Option<Requirement>,
+    pub(crate) version: Option<GoRequirement>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -26,7 +26,7 @@ pub(crate) enum ReadGoModConfigError {
 pub(crate) fn read_gomod_config<P: AsRef<path::Path>>(
     gomod_path: P,
 ) -> Result<GoModConfig, ReadGoModConfigError> {
-    let mut version: Option<Requirement> = None;
+    let mut version: Option<GoRequirement> = None;
     let mut packages: Option<Vec<String>> = None;
     let file = fs::File::open(gomod_path)?;
     for line_result in BufReader::new(file).lines() {
@@ -37,11 +37,11 @@ pub(crate) fn read_gomod_config<P: AsRef<path::Path>>(
                 packages = Some(parts.map(ToString::to_string).collect());
             }
             (Some("//"), Some("+heroku"), Some("goVersion"), Some(vrs)) => {
-                version = Requirement::parse_go(vrs).map(Some)?;
+                version = GoRequirement::parse_go(vrs).map(Some)?;
             }
             (Some("go"), Some(vrs), None, None) => {
                 if version.is_none() {
-                    version = Requirement::parse_go(&format!("={vrs}")).map(Some)?;
+                    version = GoRequirement::parse_go(&format!("={vrs}")).map(Some)?;
                 }
             }
             _ => (),

--- a/buildpacks/go/src/cfg.rs
+++ b/buildpacks/go/src/cfg.rs
@@ -37,11 +37,11 @@ pub(crate) fn read_gomod_config<P: AsRef<path::Path>>(
                 packages = Some(parts.map(ToString::to_string).collect());
             }
             (Some("//"), Some("+heroku"), Some("goVersion"), Some(vrs)) => {
-                version = GoRequirement::parse_go(vrs).map(Some)?;
+                version = GoRequirement::parse(vrs).map(Some)?;
             }
             (Some("go"), Some(vrs), None, None) => {
                 if version.is_none() {
-                    version = GoRequirement::parse_go(&format!("={vrs}")).map(Some)?;
+                    version = GoRequirement::parse(&format!("={vrs}")).map(Some)?;
                 }
             }
             _ => (),

--- a/buildpacks/go/src/layers/build.rs
+++ b/buildpacks/go/src/layers/build.rs
@@ -1,5 +1,6 @@
 use crate::{GoBuildpack, GoBuildpackError};
 use heroku_go_utils::inv::Artifact;
+use heroku_go_utils::vrs::GoVersion;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
@@ -12,13 +13,13 @@ use std::path::Path;
 
 /// A layer for go incremental build cache artifacts
 pub(crate) struct BuildLayer {
-    pub(crate) artifact: Artifact,
+    pub(crate) artifact: Artifact<GoVersion>,
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq)]
 pub(crate) struct BuildLayerMetadata {
     layer_version: String,
-    artifact: Artifact,
+    artifact: Artifact<GoVersion>,
     cache_usage_count: f32,
 }
 

--- a/buildpacks/go/src/layers/dist.rs
+++ b/buildpacks/go/src/layers/dist.rs
@@ -1,5 +1,6 @@
 use crate::{tgz, GoBuildpack, GoBuildpackError};
 use heroku_go_utils::inv::Artifact;
+use heroku_go_utils::vrs::GoVersion;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
@@ -11,13 +12,13 @@ use std::path::Path;
 
 /// A layer that downloads and installs the Go distribution artifacts
 pub(crate) struct DistLayer {
-    pub(crate) artifact: Artifact,
+    pub(crate) artifact: Artifact<GoVersion>,
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub(crate) struct DistLayerMetadata {
     layer_version: String,
-    artifact: Artifact,
+    artifact: Artifact<GoVersion>,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -5,7 +5,7 @@ mod proc;
 mod tgz;
 
 use heroku_go_utils::inv::Inventory;
-use heroku_go_utils::vrs::GoRequirement;
+use heroku_go_utils::vrs::{GoRequirement, GoVersion};
 use layers::build::{BuildLayer, BuildLayerError};
 use layers::deps::{DepsLayer, DepsLayerError};
 use layers::dist::{DistLayer, DistLayerError};
@@ -62,7 +62,8 @@ impl Buildpack for GoBuildpack {
                 go_env.insert(k, v);
             });
 
-        let inv: Inventory = toml::from_str(INVENTORY).map_err(GoBuildpackError::InventoryParse)?;
+        let inv: Inventory<GoVersion> =
+            toml::from_str(INVENTORY).map_err(GoBuildpackError::InventoryParse)?;
 
         let config = cfg::read_gomod_config(context.app_dir.join("go.mod"))
             .map_err(GoBuildpackError::GoModConfig)?;

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -5,7 +5,7 @@ mod proc;
 mod tgz;
 
 use heroku_go_utils::inv::Inventory;
-use heroku_go_utils::vrs::Requirement;
+use heroku_go_utils::vrs::GoRequirement;
 use layers::build::{BuildLayer, BuildLayerError};
 use layers::deps::{DepsLayer, DepsLayerError};
 use layers::dist::{DistLayer, DistLayerError};
@@ -70,7 +70,7 @@ impl Buildpack for GoBuildpack {
         log_info(format!("Detected Go version requirement: {requirement}"));
 
         let artifact = inv
-            .resolve(&requirement)
+            .resolve(requirement.clone())
             .ok_or(GoBuildpackError::VersionResolution(requirement))?;
         log_info(format!("Resolved Go version: {artifact}"));
 
@@ -186,7 +186,7 @@ enum GoBuildpackError {
     #[error("Couldn't parse go artifact inventory: {0}")]
     InventoryParse(toml::de::Error),
     #[error("Couldn't resolve go version for: {0}")]
-    VersionResolution(Requirement),
+    VersionResolution(GoRequirement),
     #[error("Launch process error: {0}")]
     Proc(proc::Error),
 }

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -70,7 +70,7 @@ impl Buildpack for GoBuildpack {
         log_info(format!("Detected Go version requirement: {requirement}"));
 
         let artifact = inv
-            .resolve(requirement.clone())
+            .resolve(&requirement)
             .ok_or(GoBuildpackError::VersionResolution(requirement))?;
         log_info(format!("Resolved Go version: {artifact}"));
 

--- a/common/go-utils/src/bin/diff_inventory.rs
+++ b/common/go-utils/src/bin/diff_inventory.rs
@@ -1,7 +1,10 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
 
-use heroku_go_utils::inv::{list_upstream_artifacts, Artifact, Inventory};
+use heroku_go_utils::{
+    inv::{list_upstream_artifacts, Artifact, Inventory},
+    vrs::GoVersion,
+};
 use std::collections::HashSet;
 
 /// Prints a human-readable software inventory difference. Useful
@@ -13,7 +16,7 @@ fn main() {
         std::process::exit(1);
     });
 
-    let upstream_artifacts: HashSet<Artifact> = list_upstream_artifacts()
+    let upstream_artifacts: HashSet<Artifact<GoVersion>> = list_upstream_artifacts()
         .unwrap_or_else(|e| {
             eprintln!("Failed to fetch upstream go versions: {e}");
             std::process::exit(1)
@@ -21,7 +24,7 @@ fn main() {
         .into_iter()
         .collect();
 
-    let inventory_artifacts: HashSet<Artifact> = Inventory::read(&inventory_path)
+    let inventory_artifacts: HashSet<Artifact<GoVersion>> = Inventory::read(&inventory_path)
         .unwrap_or_else(|e| {
             eprintln!("Error reading inventory at '{inventory_path}': {e}");
             std::process::exit(1);
@@ -37,7 +40,7 @@ fn main() {
     .iter()
     .filter(|(_, artifact_diff)| !artifact_diff.is_empty())
     .for_each(|(action, artifacts)| {
-        let mut list: Vec<&Artifact> = artifacts.iter().collect();
+        let mut list: Vec<&Artifact<GoVersion>> = artifacts.iter().collect();
         list.sort_by_key(|a| &a.semantic_version);
         println!(
             "{} {}.",

--- a/common/go-utils/src/inv.rs
+++ b/common/go-utils/src/inv.rs
@@ -18,16 +18,16 @@ where
 {
     pub artifacts: Vec<Artifact<V>>,
 }
-/// Represents a known go release artifact in the inventory.
+/// Represents a known artifact in the inventory.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Artifact<V>
 where
     V: Version,
 {
-    pub version: String,
+    version: String,
     pub semantic_version: V,
-    pub os: Os,
-    pub arch: Arch,
+    os: Os,
+    arch: Arch,
     pub url: String,
     pub checksum: Checksum,
 }
@@ -46,7 +46,7 @@ impl<V: Version> Display for Artifact<V> {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-pub enum Os {
+enum Os {
     Linux,
 }
 
@@ -75,7 +75,7 @@ impl FromStr for Os {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-pub enum Arch {
+enum Arch {
     X86_64,
     Aarch64,
 }

--- a/common/go-utils/src/inv.rs
+++ b/common/go-utils/src/inv.rs
@@ -1,5 +1,5 @@
 use crate::checksum::{Algorithm, Checksum, Error as ChecksumError};
-use crate::vrs::{GoVersion, Requirement, VersionParseError};
+use crate::vrs::{GoVersion, VersionParseError, VersionRequirement};
 use core::fmt::{self, Display};
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
@@ -121,7 +121,10 @@ impl Inventory {
     /// Find the first artifact from the inventory that satisfies a
     /// `Requirement`.
     #[must_use]
-    pub fn resolve(&self, requirement: &Requirement) -> Option<&Artifact> {
+    pub fn resolve<V>(&self, requirement: V) -> Option<&Artifact>
+    where
+        V: VersionRequirement,
+    {
         match (consts::OS.parse::<Os>(), consts::ARCH.parse::<Arch>()) {
             (Ok(os), Ok(arch)) => self
                 .artifacts

--- a/common/go-utils/src/inv.rs
+++ b/common/go-utils/src/inv.rs
@@ -121,9 +121,9 @@ impl Inventory {
     /// Find the first artifact from the inventory that satisfies a
     /// `Requirement`.
     #[must_use]
-    pub fn resolve<V>(&self, requirement: V) -> Option<&Artifact>
+    pub fn resolve<V>(&self, requirement: &V) -> Option<&Artifact>
     where
-        V: VersionRequirement,
+        V: VersionRequirement<GoVersion>,
     {
         match (consts::OS.parse::<Os>(), consts::ARCH.parse::<Arch>()) {
             (Ok(os), Ok(arch)) => self

--- a/common/go-utils/src/inv.rs
+++ b/common/go-utils/src/inv.rs
@@ -1,5 +1,5 @@
 use crate::checksum::{Algorithm, Checksum, Error as ChecksumError};
-use crate::vrs::{Requirement, Version, VersionParseError};
+use crate::vrs::{GoVersion, Requirement, VersionParseError};
 use core::fmt::{self, Display};
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
@@ -19,7 +19,7 @@ pub struct Inventory {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Artifact {
     pub version: String,
-    pub semantic_version: Version,
+    pub semantic_version: GoVersion,
     pub os: Os,
     pub arch: Arch,
     pub url: String,
@@ -165,7 +165,7 @@ impl TryFrom<&GoFile> for Artifact {
     fn try_from(value: &GoFile) -> Result<Self, Self::Error> {
         Ok(Artifact {
             version: value.version.clone(),
-            semantic_version: Version::parse_go(&value.version)?,
+            semantic_version: GoVersion::parse_go(&value.version)?,
             os: value.os.parse::<Os>()?,
             arch: value.arch.parse::<Arch>()?,
             checksum: Checksum::new(Algorithm::Sha256, value.sha256.to_string())?,
@@ -263,7 +263,7 @@ mod tests {
     fn create_artifact() -> Artifact {
         Artifact {
             version: String::from("go1.7.2"),
-            semantic_version: Version::parse("1.7.2").unwrap(),
+            semantic_version: GoVersion::parse("1.7.2").unwrap(),
             os: Os::Linux,
             arch: Arch::X86_64,
             url: String::from("foo"),

--- a/common/go-utils/src/inv.rs
+++ b/common/go-utils/src/inv.rs
@@ -54,7 +54,7 @@ impl Inventory {
     /// Will return an Err if the file is missing, not readable, or if the
     /// file contents is not formatted properly.
     pub fn read(path: &str) -> Result<Self, ReadInventoryError> {
-        Ok(toml::from_str(&fs::read_to_string(path)?)?)
+        toml::from_str(&fs::read_to_string(path)?).map_err(ReadInventoryError::Parse)
     }
 
     /// Find the first artifact from the inventory that satisfies a

--- a/common/go-utils/src/inv.rs
+++ b/common/go-utils/src/inv.rs
@@ -38,6 +38,67 @@ impl Display for Artifact {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Os {
+    Linux,
+}
+
+impl Display for Os {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Os::Linux => write!(f, "linux"),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("OS is not supported: {0}")]
+pub struct UnsupportedOsError(String);
+
+impl FromStr for Os {
+    type Err = UnsupportedOsError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "linux" => Ok(Os::Linux),
+            _ => Err(UnsupportedOsError(s.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Arch {
+    X86_64,
+    Aarch64,
+}
+
+impl Display for Arch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Arch::X86_64 => write!(f, "x86_64"),
+            Arch::Aarch64 => write!(f, "aarch64"),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("Arch is not supported: {0}")]
+pub struct UnsupportedArchError(String);
+
+impl FromStr for Arch {
+    type Err = UnsupportedArchError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "amd64" | "x86_64" => Ok(Arch::X86_64),
+            "arm64" | "aarch64" => Ok(Arch::Aarch64),
+            _ => Err(UnsupportedArchError(s.to_string())),
+        }
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum ReadInventoryError {
     #[error("Couldn't read Go artifact inventory.toml: {0}")]
@@ -84,67 +145,6 @@ struct GoFile {
     filename: String,
     sha256: String,
     version: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum Arch {
-    X86_64,
-    Aarch64,
-}
-
-impl Display for Arch {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Arch::X86_64 => write!(f, "x86_64"),
-            Arch::Aarch64 => write!(f, "aarch64"),
-        }
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-#[error("Arch is not supported: {0}")]
-pub struct UnsupportedArchError(String);
-
-impl FromStr for Arch {
-    type Err = UnsupportedArchError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "amd64" | "x86_64" => Ok(Arch::X86_64),
-            "arm64" | "aarch64" => Ok(Arch::Aarch64),
-            _ => Err(UnsupportedArchError(s.to_string())),
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum Os {
-    Linux,
-}
-
-impl Display for Os {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Os::Linux => write!(f, "linux"),
-        }
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-#[error("OS is not supported: {0}")]
-pub struct UnsupportedOsError(String);
-
-impl FromStr for Os {
-    type Err = UnsupportedOsError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "linux" => Ok(Os::Linux),
-            _ => Err(UnsupportedOsError(s.to_string())),
-        }
-    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -53,7 +53,7 @@ impl Requirement {
 
     /// Determines if a `&Version` satisfies a `Requirement`
     #[must_use]
-    pub fn satisfies(&self, version: &Version) -> bool {
+    pub(crate) fn satisfies(&self, version: &Version) -> bool {
         self.0.matches(&version.0)
     }
 }

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -27,7 +27,9 @@ impl Requirement {
     /// Invalid semver requirement `&str` like ">< 1.0", ".1.0", "!=4", etc.
     /// will return an error.
     pub fn parse(input: &str) -> Result<Self, RequirementParseError> {
-        Ok(semver::VersionReq::parse(input).map(Self)?)
+        semver::VersionReq::parse(input)
+            .map(Self)
+            .map_err(RequirementParseError)
     }
 
     /// Parses a go version requirement `&str` as a `Requirement`

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -135,6 +135,7 @@ impl Version {
 
 impl TryFrom<String> for Version {
     type Error = VersionParseError;
+
     fn try_from(val: String) -> Result<Self, Self::Error> {
         Version::parse(&val)
     }

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -14,12 +14,12 @@ pub struct GoRequirement(semver::VersionReq);
 #[error("Couldn't parse Go version requirement: {0}")]
 pub struct RequirementParseError(#[from] semver::Error);
 
-pub trait Version {}
+pub trait Version: Clone {}
 
 impl Version for GoVersion {}
 pub trait VersionRequirement<T>: Display
 where
-    T: Version,
+    T: Version + std::marker::Sized,
 {
     fn satisfies(&self, version: &T) -> bool;
 

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use semver;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::fmt::{self, Display};
 
 /// `Requirement` is a wrapper around `semver::Requirement` that adds
 /// - Ability to parse go-flavored requirements
@@ -17,7 +17,7 @@ pub struct RequirementParseError(#[from] semver::Error);
 pub trait Version {}
 
 impl Version for GoVersion {}
-pub trait VersionRequirement<T>
+pub trait VersionRequirement<T>: Display
 where
     T: Version,
 {

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -14,7 +14,13 @@ pub struct GoRequirement(semver::VersionReq);
 #[error("Couldn't parse Go version requirement: {0}")]
 pub struct RequirementParseError(#[from] semver::Error);
 
-pub trait VersionRequirement<T> {
+pub trait Version {}
+
+impl Version for GoVersion {}
+pub trait VersionRequirement<T>
+where
+    T: Version,
+{
     fn satisfies(&self, version: &T) -> bool;
 
     /// Parses a go version requirement `&str` as a `Requirement`

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, fmt};
 /// - Ability to parse go-flavored requirements
 ///
 /// The derived `Default` implementation creates a wildcard version `Requirement`.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
 #[serde(try_from = "String", into = "String")]
 pub struct Requirement(semver::VersionReq);
 
@@ -54,13 +54,6 @@ impl Requirement {
     #[must_use]
     pub fn satisfies(&self, version: &Version) -> bool {
         self.0.matches(&version.0)
-    }
-}
-
-impl TryFrom<String> for Requirement {
-    type Error = RequirementParseError;
-    fn try_from(val: String) -> Result<Self, Self::Error> {
-        Requirement::parse(&val)
     }
 }
 

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -8,8 +8,7 @@ use std::{borrow::Cow, fmt};
 /// - Ability to parse go-flavored requirements
 ///
 /// The derived `Default` implementation creates a wildcard version `Requirement`.
-#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
-#[serde(try_from = "String", into = "String")]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Requirement(semver::VersionReq);
 
 #[derive(thiserror::Error, Debug)]
@@ -54,12 +53,6 @@ impl Requirement {
     #[must_use]
     pub fn satisfies(&self, version: &Version) -> bool {
         self.0.matches(&version.0)
-    }
-}
-
-impl From<Requirement> for String {
-    fn from(req: Requirement) -> Self {
-        format!("{req}")
     }
 }
 

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -91,7 +91,7 @@ impl Version {
     ///
     /// Invalid semver `&str`s like ".1", "1.*", "abc", etc. will return an error.
     pub fn parse(version: &str) -> Result<Version, VersionParseError> {
-        Ok(semver::Version::parse(version.trim()).map(Version)?)
+        Ok(semver::Version::parse(version).map(Version)?)
     }
 
     /// Parses a go version `&str` as a `Version`

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt};
 
 /// `Requirement` is a wrapper around `semver::Requirement` that adds
-/// - `Deserialize` and `Serialize` traits
 /// - Ability to parse go-flavored requirements
 ///
 /// The derived `Default` implementation creates a wildcard version `Requirement`.

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -94,7 +94,9 @@ impl Version {
     ///
     /// Invalid semver `&str`s like ".1", "1.*", "abc", etc. will return an error.
     pub fn parse(version: &str) -> Result<Version, VersionParseError> {
-        Ok(semver::Version::parse(version).map(Version)?)
+        semver::Version::parse(version)
+            .map(Version)
+            .map_err(VersionParseError::SemVer)
     }
 
     /// Parses a go version `&str` as a `Version`

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -53,7 +53,7 @@ impl Requirement {
 
     /// Determines if a `&Version` satisfies a `Requirement`
     #[must_use]
-    pub(crate) fn satisfies(&self, version: &Version) -> bool {
+    pub(crate) fn satisfies(&self, version: &GoVersion) -> bool {
         self.0.matches(&version.0)
     }
 }
@@ -69,7 +69,7 @@ impl fmt::Display for Requirement {
 /// - Ability to parse go-flavored versions
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(try_from = "String", into = "String")]
-pub struct Version(semver::Version);
+pub struct GoVersion(semver::Version);
 
 #[derive(thiserror::Error, Debug)]
 pub enum VersionParseError {
@@ -81,7 +81,7 @@ pub enum VersionParseError {
     Captures,
 }
 
-impl Version {
+impl GoVersion {
     /// Parses a semver `&str` as a `Version`
     ///
     /// # Examples
@@ -93,9 +93,9 @@ impl Version {
     /// # Errors
     ///
     /// Invalid semver `&str`s like ".1", "1.*", "abc", etc. will return an error.
-    pub fn parse(version: &str) -> Result<Version, VersionParseError> {
+    pub fn parse(version: &str) -> Result<GoVersion, VersionParseError> {
         semver::Version::parse(version)
-            .map(Version)
+            .map(GoVersion)
             .map_err(VersionParseError::SemVer)
     }
 
@@ -110,7 +110,7 @@ impl Version {
     /// # Errors
     ///
     /// Invalid go version `&str`s like ".1", "1.*", "abc", etc. will return an error.
-    pub fn parse_go(go_version: &str) -> Result<Version, VersionParseError> {
+    pub fn parse_go(go_version: &str) -> Result<GoVersion, VersionParseError> {
         let stripped_version = go_version.strip_prefix("go").unwrap_or(go_version);
 
         let caps = Regex::new(r"^(\d+)\.?(\d+)?\.?(\d+)?([a-z][a-z0-9]*)?$")?
@@ -129,25 +129,25 @@ impl Version {
             composed_version.push_str(pre.as_str());
         };
 
-        Version::parse(&composed_version)
+        GoVersion::parse(&composed_version)
     }
 }
 
-impl TryFrom<String> for Version {
+impl TryFrom<String> for GoVersion {
     type Error = VersionParseError;
 
     fn try_from(val: String) -> Result<Self, Self::Error> {
-        Version::parse(&val)
+        GoVersion::parse(&val)
     }
 }
 
-impl From<Version> for String {
-    fn from(ver: Version) -> Self {
+impl From<GoVersion> for String {
+    fn from(ver: GoVersion) -> Self {
         format!("{ver}")
     }
 }
 
-impl fmt::Display for Version {
+impl fmt::Display for GoVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -175,10 +175,10 @@ mod tests {
         ];
 
         for (input, expected_str) in go_versions {
-            let actual = Version::parse_go(input).expect("Failed to parse go input version");
+            let actual = GoVersion::parse_go(input).expect("Failed to parse go input version");
             let actual_str = actual.to_string();
             let expected =
-                Version::parse(expected_str).expect("Failed to parse go expected version");
+                GoVersion::parse(expected_str).expect("Failed to parse go expected version");
             assert_eq!(
                 expected, actual,
                 "Expected {input} to parse as {expected} but got {actual}."

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use semver;
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, fmt};
+use std::fmt;
 
 /// `Requirement` is a wrapper around `semver::Requirement` that adds
 /// - Ability to parse go-flavored requirements
@@ -44,10 +44,11 @@ impl Requirement {
     /// Invalid semver requirement `&str` like ">< 1.0", ".1.0", "!=4", etc.
     /// will return an error.
     pub fn parse_go(go_req: &str) -> Result<Self, RequirementParseError> {
-        let stripped_req = go_req
+        go_req
             .strip_prefix("go")
-            .map_or(Cow::Borrowed(go_req), |req| Cow::Owned(format!("={req}")));
-        Self::parse(&stripped_req)
+            .map_or(Self::parse(go_req), |req| {
+                Self::parse(format!("={req}").as_str())
+            })
     }
 
     /// Determines if a `&Version` satisfies a `Requirement`

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -113,8 +113,7 @@ impl Version {
     pub fn parse_go(go_version: &str) -> Result<Version, VersionParseError> {
         let stripped_version = go_version.strip_prefix("go").unwrap_or(go_version);
 
-        let re = Regex::new(r"^(\d+)\.?(\d+)?\.?(\d+)?([a-z][a-z0-9]*)?$")?;
-        let caps = re
+        let caps = Regex::new(r"^(\d+)\.?(\d+)?\.?(\d+)?([a-z][a-z0-9]*)?$")?
             .captures(stripped_version)
             .ok_or(VersionParseError::Captures)?;
 

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -30,6 +30,20 @@ pub trait VersionRequirement {
     /// Invalid semver requirement `&str` like ">< 1.0", ".1.0", "!=4", etc.
     /// will return an error.
     fn parse_go(go_req: &str) -> Result<GoRequirement, RequirementParseError>;
+
+    /// Parses a semver requirement `&str` as a `Requirement`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heroku_go_utils::vrs::VersionRequirement;
+    /// let req = heroku_go_utils::vrs::GoRequirement::parse("~1.0").unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Invalid semver requirement `&str` like ">< 1.0", ".1.0", "!=4", etc.
+    /// will return an error.
+    fn parse(input: &str) -> Result<GoRequirement, RequirementParseError>;
 }
 
 impl VersionRequirement for GoRequirement {
@@ -44,21 +58,8 @@ impl VersionRequirement for GoRequirement {
                 Self::parse(format!("={req}").as_str())
             })
     }
-}
 
-impl GoRequirement {
-    /// Parses a semver requirement `&str` as a `Requirement`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let req = heroku_go_utils::vrs::GoRequirement::parse("~1.0").unwrap();
-    /// ```
-    ///
-    /// # Errors
-    /// Invalid semver requirement `&str` like ">< 1.0", ".1.0", "!=4", etc.
-    /// will return an error.
-    pub fn parse(input: &str) -> Result<Self, RequirementParseError> {
+    fn parse(input: &str) -> Result<Self, RequirementParseError> {
         semver::VersionReq::parse(input)
             .map(Self)
             .map_err(RequirementParseError)

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use semver;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 /// `Requirement` is a wrapper around `semver::Requirement` that adds
 /// - Ability to parse go-flavored requirements
@@ -14,13 +14,10 @@ pub struct GoRequirement(semver::VersionReq);
 #[error("Couldn't parse Go version requirement: {0}")]
 pub struct RequirementParseError(#[from] semver::Error);
 
-pub trait Version: Clone {}
+pub trait Version {}
 
 impl Version for GoVersion {}
-pub trait VersionRequirement<T>: Display
-where
-    T: Version + std::marker::Sized,
-{
+pub trait VersionRequirement<T> {
     fn satisfies(&self, version: &T) -> bool;
 
     /// Parses a semver requirement `&str` as a `Requirement`.

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, fmt};
 /// - Ability to parse go-flavored requirements
 ///
 /// The derived `Default` implementation creates a wildcard version `Requirement`.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct Requirement(semver::VersionReq);
 
 #[derive(thiserror::Error, Debug)]

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -14,8 +14,8 @@ pub struct GoRequirement(semver::VersionReq);
 #[error("Couldn't parse Go version requirement: {0}")]
 pub struct RequirementParseError(#[from] semver::Error);
 
-pub trait VersionRequirement {
-    fn satisfies(&self, version: &GoVersion) -> bool;
+pub trait VersionRequirement<T> {
+    fn satisfies(&self, version: &T) -> bool;
 
     /// Parses a go version requirement `&str` as a `Requirement`
     ///
@@ -29,7 +29,9 @@ pub trait VersionRequirement {
     /// # Errors
     /// Invalid semver requirement `&str` like ">< 1.0", ".1.0", "!=4", etc.
     /// will return an error.
-    fn parse_go(go_req: &str) -> Result<GoRequirement, RequirementParseError>;
+    fn parse_go(go_req: &str) -> Result<Self, RequirementParseError>
+    where
+        Self: std::marker::Sized;
 
     /// Parses a semver requirement `&str` as a `Requirement`.
     ///
@@ -43,15 +45,17 @@ pub trait VersionRequirement {
     /// # Errors
     /// Invalid semver requirement `&str` like ">< 1.0", ".1.0", "!=4", etc.
     /// will return an error.
-    fn parse(input: &str) -> Result<GoRequirement, RequirementParseError>;
+    fn parse(input: &str) -> Result<Self, RequirementParseError>
+    where
+        Self: std::marker::Sized;
 }
 
-impl VersionRequirement for GoRequirement {
+impl VersionRequirement<GoVersion> for GoRequirement {
     fn satisfies<'a>(&self, version: &GoVersion) -> bool {
         self.0.matches(&version.0)
     }
 
-    fn parse_go(go_req: &str) -> Result<GoRequirement, RequirementParseError> {
+    fn parse_go(go_req: &str) -> Result<Self, RequirementParseError> {
         go_req
             .strip_prefix("go")
             .map_or(Self::parse(go_req), |req| {


### PR DESCRIPTION
This PR is the first step of an effort to refactor the binary inventory logic that can be shared to a separate library. No functional changes are introduced, but it lays the groundwork for future refactoring by:

* Renaming the `Version` struct to `GoVersion`.
* Introducing a new trait, `Version`, which is implemented by `GoVersion` (and currently doesn’t contain any functionality).
* Introducing a new trait, `VersionRequirement<V>` which accepts a `Version` parameter.
* Renaming the `Requirement` struct to `GoRequirement` which implements `VersionRequirement`, and moving the logic to the new traits required fields.

Future PRs will split and merge the functionality introduced in the `VersionRequirement` here (in particular, the `parse_go` function will be eliminated.

While the changes here don’t do much (apart from adding complexity) it’ll hopefully help make reviewing the following PRs a bit easier :)