### PR TITLE
Share inventory diff and update tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,6 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
- "toml",
  "ureq",
 ]
 

--- a/common/go-utils/Cargo.toml
+++ b/common/go-utils/Cargo.toml
@@ -11,6 +11,5 @@ regex = "1"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
-toml = "0.8"
 ureq = { version = "2", features = ["json"] }
 heroku-inventory-utils = { path = "../../common/inventory-utils" }

--- a/common/go-utils/src/bin/diff_inventory.rs
+++ b/common/go-utils/src/bin/diff_inventory.rs
@@ -1,7 +1,8 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
 
-use heroku_go_utils::{inv::list_upstream_artifacts, vrs::GoVersion};
+use heroku_go_utils::vrs::GoVersion;
+use heroku_inventory_utils::inv::UpstreamInventory;
 use heroku_inventory_utils::inv::{Artifact, Inventory};
 use std::collections::HashSet;
 
@@ -14,13 +15,11 @@ fn main() {
         std::process::exit(1);
     });
 
-    let upstream_artifacts: HashSet<Artifact<GoVersion>> = list_upstream_artifacts()
+    let upstream_artifacts: HashSet<Artifact<GoVersion>> = Inventory::list_upstream_artifacts()
         .unwrap_or_else(|e| {
             eprintln!("Failed to fetch upstream go versions: {e}");
             std::process::exit(1)
-        })
-        .into_iter()
-        .collect();
+        });
 
     let inventory_artifacts: HashSet<Artifact<GoVersion>> = Inventory::read(&inventory_path)
         .unwrap_or_else(|e| {

--- a/common/go-utils/src/bin/diff_inventory.rs
+++ b/common/go-utils/src/bin/diff_inventory.rs
@@ -9,9 +9,5 @@ use heroku_inventory_utils::upstream::UpstreamInventory;
 /// for generating commit messages and changelogs for automated inventory
 /// updates.
 fn main() {
-    let path = std::env::args().nth(1).unwrap_or_else(|| {
-        eprintln!("$ diff_inventory path/to/inventory.toml");
-        std::process::exit(1);
-    });
-    Inventory::<GoVersion>::diff_inventory(path);
+    Inventory::<GoVersion>::diff_inventory();
 }

--- a/common/go-utils/src/bin/diff_inventory.rs
+++ b/common/go-utils/src/bin/diff_inventory.rs
@@ -5,9 +5,6 @@ use heroku_go_utils::vrs::GoVersion;
 use heroku_inventory_utils::inv::Inventory;
 use heroku_inventory_utils::upstream::UpstreamInventory;
 
-/// Prints a human-readable software inventory difference. Useful
-/// for generating commit messages and changelogs for automated inventory
-/// updates.
 fn main() {
     Inventory::<GoVersion>::diff_inventory();
 }

--- a/common/go-utils/src/bin/diff_inventory.rs
+++ b/common/go-utils/src/bin/diff_inventory.rs
@@ -6,5 +6,5 @@ use heroku_inventory_utils::inv::Inventory;
 use heroku_inventory_utils::upstream::UpstreamInventory;
 
 fn main() {
-    Inventory::<GoVersion>::diff_inventory();
+    Inventory::<GoVersion>::print_diff();
 }

--- a/common/go-utils/src/bin/diff_inventory.rs
+++ b/common/go-utils/src/bin/diff_inventory.rs
@@ -3,7 +3,7 @@
 
 use heroku_go_utils::vrs::GoVersion;
 use heroku_inventory_utils::inv::Inventory;
-use heroku_inventory_utils::inv::UpstreamInventory;
+use heroku_inventory_utils::upstream::UpstreamInventory;
 
 /// Prints a human-readable software inventory difference. Useful
 /// for generating commit messages and changelogs for automated inventory

--- a/common/go-utils/src/bin/diff_inventory.rs
+++ b/common/go-utils/src/bin/diff_inventory.rs
@@ -2,51 +2,16 @@
 #![allow(unused_crate_dependencies)]
 
 use heroku_go_utils::vrs::GoVersion;
+use heroku_inventory_utils::inv::Inventory;
 use heroku_inventory_utils::inv::UpstreamInventory;
-use heroku_inventory_utils::inv::{Artifact, Inventory};
-use std::collections::HashSet;
 
 /// Prints a human-readable software inventory difference. Useful
 /// for generating commit messages and changelogs for automated inventory
 /// updates.
 fn main() {
-    let inventory_path = std::env::args().nth(1).unwrap_or_else(|| {
+    let path = std::env::args().nth(1).unwrap_or_else(|| {
         eprintln!("$ diff_inventory path/to/inventory.toml");
         std::process::exit(1);
     });
-
-    let upstream_artifacts: HashSet<Artifact<GoVersion>> = Inventory::list_upstream_artifacts()
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to fetch upstream go versions: {e}");
-            std::process::exit(1)
-        });
-
-    let inventory_artifacts: HashSet<Artifact<GoVersion>> = Inventory::read(&inventory_path)
-        .unwrap_or_else(|e| {
-            eprintln!("Error reading inventory at '{inventory_path}': {e}");
-            std::process::exit(1);
-        })
-        .artifacts
-        .into_iter()
-        .collect();
-
-    [
-        ("Added", &upstream_artifacts - &inventory_artifacts),
-        ("Removed", &inventory_artifacts - &upstream_artifacts),
-    ]
-    .iter()
-    .filter(|(_, artifact_diff)| !artifact_diff.is_empty())
-    .for_each(|(action, artifacts)| {
-        let mut list: Vec<&Artifact<GoVersion>> = artifacts.iter().collect();
-        list.sort();
-        list.reverse();
-        println!(
-            "{} {}.",
-            action,
-            list.iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
-    });
+    Inventory::<GoVersion>::diff_inventory(path);
 }

--- a/common/go-utils/src/bin/update_inventory.rs
+++ b/common/go-utils/src/bin/update_inventory.rs
@@ -6,5 +6,5 @@ use heroku_inventory_utils::inv::Inventory;
 use heroku_inventory_utils::upstream::UpstreamInventory;
 
 fn main() {
-    Inventory::<GoVersion>::update_local();
+    Inventory::<GoVersion>::pull();
 }

--- a/common/go-utils/src/bin/update_inventory.rs
+++ b/common/go-utils/src/bin/update_inventory.rs
@@ -4,14 +4,8 @@
 use heroku_go_utils::vrs::GoVersion;
 use heroku_inventory_utils::inv::Inventory;
 use heroku_inventory_utils::upstream::UpstreamInventory;
-use std::{env, process};
 
 /// Updates the local go inventory.toml with versions published on go.dev.
 fn main() {
-    let path = env::args().nth(1).unwrap_or_else(|| {
-        eprintln!("Usage: update_inventory <path/to/inventory.toml>");
-        process::exit(2);
-    });
-
-    Inventory::<GoVersion>::update_local(path);
+    Inventory::<GoVersion>::update_local();
 }

--- a/common/go-utils/src/bin/update_inventory.rs
+++ b/common/go-utils/src/bin/update_inventory.rs
@@ -3,7 +3,7 @@
 
 use heroku_go_utils::vrs::GoVersion;
 use heroku_inventory_utils::inv::Inventory;
-use heroku_inventory_utils::inv::UpstreamInventory;
+use heroku_inventory_utils::upstream::UpstreamInventory;
 use std::{env, process};
 
 /// Updates the local go inventory.toml with versions published on go.dev.

--- a/common/go-utils/src/bin/update_inventory.rs
+++ b/common/go-utils/src/bin/update_inventory.rs
@@ -2,40 +2,16 @@
 #![allow(unused_crate_dependencies)]
 
 use heroku_go_utils::vrs::GoVersion;
+use heroku_inventory_utils::inv::Inventory;
 use heroku_inventory_utils::inv::UpstreamInventory;
-use heroku_inventory_utils::inv::{Artifact, Inventory};
-use std::{env, fs, process};
+use std::{env, process};
 
 /// Updates the local go inventory.toml with versions published on go.dev.
 fn main() {
-    let filename = env::args().nth(1).unwrap_or_else(|| {
+    let path = env::args().nth(1).unwrap_or_else(|| {
         eprintln!("Usage: update_inventory <path/to/inventory.toml>");
         process::exit(2);
     });
 
-    // List available upstream release versions.
-    let mut remote_artifacts: Vec<Artifact<GoVersion>> = Inventory::list_upstream_artifacts()
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to fetch upstream go versions: {e}");
-            process::exit(4);
-        })
-        .into_iter()
-        .collect();
-
-    remote_artifacts.sort();
-    remote_artifacts.reverse();
-
-    let inventory = Inventory {
-        artifacts: remote_artifacts,
-    };
-
-    let toml = toml::to_string(&inventory).unwrap_or_else(|e| {
-        eprintln!("Error serializing inventory as toml: {e}");
-        process::exit(6);
-    });
-
-    fs::write(filename, toml).unwrap_or_else(|e| {
-        eprintln!("Error writing inventory to file: {e}");
-        process::exit(7);
-    });
+    Inventory::<GoVersion>::update_local(path);
 }

--- a/common/go-utils/src/bin/update_inventory.rs
+++ b/common/go-utils/src/bin/update_inventory.rs
@@ -5,7 +5,6 @@ use heroku_go_utils::vrs::GoVersion;
 use heroku_inventory_utils::inv::Inventory;
 use heroku_inventory_utils::upstream::UpstreamInventory;
 
-/// Updates the local go inventory.toml with versions published on go.dev.
 fn main() {
     Inventory::<GoVersion>::update_local();
 }

--- a/common/go-utils/src/bin/update_inventory.rs
+++ b/common/go-utils/src/bin/update_inventory.rs
@@ -1,8 +1,9 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
 
-use heroku_go_utils::inv::list_upstream_artifacts;
-use heroku_inventory_utils::inv::Inventory;
+use heroku_go_utils::vrs::GoVersion;
+use heroku_inventory_utils::inv::UpstreamInventory;
+use heroku_inventory_utils::inv::{Artifact, Inventory};
 use std::{env, fs, process};
 
 /// Updates the local go inventory.toml with versions published on go.dev.
@@ -13,10 +14,13 @@ fn main() {
     });
 
     // List available upstream release versions.
-    let mut remote_artifacts = list_upstream_artifacts().unwrap_or_else(|e| {
-        eprintln!("Failed to fetch upstream go versions: {e}");
-        process::exit(4);
-    });
+    let mut remote_artifacts: Vec<Artifact<GoVersion>> = Inventory::list_upstream_artifacts()
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to fetch upstream go versions: {e}");
+            process::exit(4);
+        })
+        .into_iter()
+        .collect();
 
     remote_artifacts.sort();
     remote_artifacts.reverse();

--- a/common/go-utils/src/inv.rs
+++ b/common/go-utils/src/inv.rs
@@ -1,11 +1,11 @@
-use crate::vrs;
+use crate::vrs::{GoVersion, GoVersionParseError};
 use heroku_inventory_utils::checksum::{Algorithm, Checksum, Error as ChecksumError};
 use heroku_inventory_utils::inv::{
-    Arch, Artifact, Inventory, Os, UnsupportedArchError, UnsupportedOsError, UpstreamInventory,
+    Arch, Artifact, Inventory, Os, UnsupportedArchError, UnsupportedOsError,
 };
+use heroku_inventory_utils::upstream::UpstreamInventory;
 use heroku_inventory_utils::vrs::Version;
 use serde::Deserialize;
-use vrs::{GoVersion, GoVersionParseError};
 
 const GO_RELEASES_URL: &str = "https://go.dev/dl/?mode=json&include=all";
 const GO_HOST_URL: &str = "https://go.dev/dl";

--- a/common/go-utils/src/inv.rs
+++ b/common/go-utils/src/inv.rs
@@ -85,7 +85,6 @@ impl UpstreamInventory<GoVersion> for Inventory<GoVersion> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::hash::{BuildHasher, RandomState};
 
     fn create_artifact() -> Artifact<GoVersion> {
         Artifact::<GoVersion> {
@@ -106,28 +105,5 @@ mod tests {
         let artifact = create_artifact();
 
         assert_eq!("Go 1.7.2 (linux-x86_64)", artifact.to_string());
-    }
-
-    #[test]
-    fn test_artifact_hash_implementation() {
-        let artifact = create_artifact();
-
-        let state = RandomState::new();
-        assert_eq!(
-            state.hash_one(&artifact.checksum.value),
-            state.hash_one(&artifact)
-        );
-    }
-
-    #[test]
-    fn test_artifact_serialization() {
-        let artifact = create_artifact();
-        let serialized = toml::to_string(&artifact).unwrap();
-        assert!(serialized
-            .contains("sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"));
-        assert_eq!(
-            artifact,
-            toml::from_str::<Artifact<GoVersion>>(&serialized).unwrap()
-        );
     }
 }

--- a/common/go-utils/src/lib.rs
+++ b/common/go-utils/src/lib.rs
@@ -1,4 +1,2 @@
-use toml as _;
-
 pub mod inv;
 pub mod vrs;

--- a/common/inventory-utils/src/inv.rs
+++ b/common/inventory-utils/src/inv.rs
@@ -9,83 +9,6 @@ use std::hash::Hash;
 use std::{fmt::Display, str::FromStr};
 use std::{fs, process};
 
-pub trait UpstreamInventory<V>
-where
-    V: Version + DeserializeOwned + Serialize + Clone,
-{
-    type Error: Display;
-
-    /// # Errors
-    ///
-    /// Issues listing upstream artifacts will return an Error
-    fn list_upstream_artifacts() -> Result<HashSet<Artifact<V>>, Self::Error>;
-
-    fn update_local(path: String) {
-        // List available upstream release versions.
-        let mut remote_artifacts: Vec<Artifact<V>> = Self::list_upstream_artifacts()
-            .unwrap_or_else(|e| {
-                eprintln!("Failed to fetch upstream go versions: {e}");
-                process::exit(4)
-            })
-            .into_iter()
-            .collect();
-
-        remote_artifacts.sort();
-        remote_artifacts.reverse();
-
-        let inventory = Inventory {
-            artifacts: remote_artifacts,
-        };
-
-        let toml = toml::to_string(&inventory).unwrap_or_else(|e| {
-            eprintln!("Error serializing inventory as toml: {e}");
-            process::exit(6);
-        });
-
-        fs::write(path, toml).unwrap_or_else(|e| {
-            eprintln!("Error writing inventory to file: {e}");
-            process::exit(7);
-        });
-    }
-
-    fn diff_inventory(path: String) {
-        let upstream_artifacts: HashSet<Artifact<V>> = Self::list_upstream_artifacts()
-            .unwrap_or_else(|e| {
-                eprintln!("Failed to fetch upstream go versions: {e}");
-                std::process::exit(1)
-            });
-
-        let inventory_artifacts: HashSet<Artifact<V>> = Inventory::read(&path)
-            .unwrap_or_else(|e| {
-                eprintln!("Error reading inventory at '{path}': {e}");
-                std::process::exit(1);
-            })
-            .artifacts
-            .into_iter()
-            .collect();
-
-        [
-            ("Added", &upstream_artifacts - &inventory_artifacts),
-            ("Removed", &inventory_artifacts - &upstream_artifacts),
-        ]
-        .iter()
-        .filter(|(_, artifact_diff)| !artifact_diff.is_empty())
-        .for_each(|(action, artifacts)| {
-            let mut list: Vec<&Artifact<V>> = artifacts.iter().collect();
-            list.sort();
-            list.reverse();
-            println!(
-                "{} {}.",
-                action,
-                list.iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-        });
-    }
-}
-
 /// Represents an inventory of artifacts.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Inventory<V>
@@ -230,6 +153,83 @@ where
                 .find(|artifact| requirement.satisfies(&artifact.version)),
             (_, _) => None,
         }
+    }
+}
+
+pub trait UpstreamInventory<V>
+where
+    V: Version + DeserializeOwned + Serialize + Clone,
+{
+    type Error: Display;
+
+    /// # Errors
+    ///
+    /// Issues listing upstream artifacts will return an Error
+    fn list_upstream_artifacts() -> Result<HashSet<Artifact<V>>, Self::Error>;
+
+    fn update_local(path: String) {
+        // List available upstream release versions.
+        let mut remote_artifacts: Vec<Artifact<V>> = Self::list_upstream_artifacts()
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to fetch upstream go versions: {e}");
+                process::exit(4)
+            })
+            .into_iter()
+            .collect();
+
+        remote_artifacts.sort();
+        remote_artifacts.reverse();
+
+        let inventory = Inventory {
+            artifacts: remote_artifacts,
+        };
+
+        let toml = toml::to_string(&inventory).unwrap_or_else(|e| {
+            eprintln!("Error serializing inventory as toml: {e}");
+            process::exit(6);
+        });
+
+        fs::write(path, toml).unwrap_or_else(|e| {
+            eprintln!("Error writing inventory to file: {e}");
+            process::exit(7);
+        });
+    }
+
+    fn diff_inventory(path: String) {
+        let upstream_artifacts: HashSet<Artifact<V>> = Self::list_upstream_artifacts()
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to fetch upstream go versions: {e}");
+                std::process::exit(1)
+            });
+
+        let inventory_artifacts: HashSet<Artifact<V>> = Inventory::read(&path)
+            .unwrap_or_else(|e| {
+                eprintln!("Error reading inventory at '{path}': {e}");
+                std::process::exit(1);
+            })
+            .artifacts
+            .into_iter()
+            .collect();
+
+        [
+            ("Added", &upstream_artifacts - &inventory_artifacts),
+            ("Removed", &inventory_artifacts - &upstream_artifacts),
+        ]
+        .iter()
+        .filter(|(_, artifact_diff)| !artifact_diff.is_empty())
+        .for_each(|(action, artifacts)| {
+            let mut list: Vec<&Artifact<V>> = artifacts.iter().collect();
+            list.sort();
+            list.reverse();
+            println!(
+                "{} {}.",
+                action,
+                list.iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        });
     }
 }
 

--- a/common/inventory-utils/src/inv.rs
+++ b/common/inventory-utils/src/inv.rs
@@ -3,11 +3,10 @@ use crate::{checksum::Checksum, vrs::Version};
 use core::fmt;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::env::consts;
+use std::fs;
 use std::hash::Hash;
 use std::{fmt::Display, str::FromStr};
-use std::{fs, process};
 
 /// Represents an inventory of artifacts.
 #[derive(Debug, Serialize, Deserialize)]
@@ -153,83 +152,6 @@ where
                 .find(|artifact| requirement.satisfies(&artifact.version)),
             (_, _) => None,
         }
-    }
-}
-
-pub trait UpstreamInventory<V>
-where
-    V: Version + DeserializeOwned + Serialize + Clone,
-{
-    type Error: Display;
-
-    /// # Errors
-    ///
-    /// Issues listing upstream artifacts will return an Error
-    fn list_upstream_artifacts() -> Result<HashSet<Artifact<V>>, Self::Error>;
-
-    fn update_local(path: String) {
-        // List available upstream release versions.
-        let mut remote_artifacts: Vec<Artifact<V>> = Self::list_upstream_artifacts()
-            .unwrap_or_else(|e| {
-                eprintln!("Failed to fetch upstream go versions: {e}");
-                process::exit(4)
-            })
-            .into_iter()
-            .collect();
-
-        remote_artifacts.sort();
-        remote_artifacts.reverse();
-
-        let inventory = Inventory {
-            artifacts: remote_artifacts,
-        };
-
-        let toml = toml::to_string(&inventory).unwrap_or_else(|e| {
-            eprintln!("Error serializing inventory as toml: {e}");
-            process::exit(6);
-        });
-
-        fs::write(path, toml).unwrap_or_else(|e| {
-            eprintln!("Error writing inventory to file: {e}");
-            process::exit(7);
-        });
-    }
-
-    fn diff_inventory(path: String) {
-        let upstream_artifacts: HashSet<Artifact<V>> = Self::list_upstream_artifacts()
-            .unwrap_or_else(|e| {
-                eprintln!("Failed to fetch upstream go versions: {e}");
-                std::process::exit(1)
-            });
-
-        let inventory_artifacts: HashSet<Artifact<V>> = Inventory::read(&path)
-            .unwrap_or_else(|e| {
-                eprintln!("Error reading inventory at '{path}': {e}");
-                std::process::exit(1);
-            })
-            .artifacts
-            .into_iter()
-            .collect();
-
-        [
-            ("Added", &upstream_artifacts - &inventory_artifacts),
-            ("Removed", &inventory_artifacts - &upstream_artifacts),
-        ]
-        .iter()
-        .filter(|(_, artifact_diff)| !artifact_diff.is_empty())
-        .for_each(|(action, artifacts)| {
-            let mut list: Vec<&Artifact<V>> = artifacts.iter().collect();
-            list.sort();
-            list.reverse();
-            println!(
-                "{} {}.",
-                action,
-                list.iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-        });
     }
 }
 

--- a/common/inventory-utils/src/inv.rs
+++ b/common/inventory-utils/src/inv.rs
@@ -3,10 +3,23 @@ use crate::{checksum::Checksum, vrs::Version};
 use core::fmt;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::env::consts;
 use std::fs;
 use std::hash::Hash;
 use std::{fmt::Display, str::FromStr};
+
+pub trait UpstreamInventory<V>
+where
+    V: Version,
+{
+    type Error;
+
+    /// # Errors
+    ///
+    /// Issues listing upstream artifacts will return an Error
+    fn list_upstream_artifacts() -> Result<HashSet<Artifact<V>>, Self::Error>;
+}
 
 /// Represents an inventory of artifacts.
 #[derive(Debug, Serialize, Deserialize)]

--- a/common/inventory-utils/src/lib.rs
+++ b/common/inventory-utils/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod checksum;
 pub mod inv;
 pub mod semvrs;
+pub mod upstream;
 pub mod vrs;

--- a/common/inventory-utils/src/upstream.rs
+++ b/common/inventory-utils/src/upstream.rs
@@ -21,12 +21,7 @@ where
 
     /// Updates a local inventory.toml with versions published upstream.
     fn update_local() {
-        // List available upstream release versions.
-
-        let path = env::args().nth(1).unwrap_or_else(|| {
-            eprintln!("Usage: update_inventory <path/to/inventory.toml>");
-            process::exit(2);
-        });
+        let path = inventory_path();
 
         let mut remote_artifacts: Vec<Artifact<V>> = Self::list_upstream_artifacts()
             .unwrap_or_else(|e| {
@@ -97,4 +92,11 @@ where
             );
         });
     }
+}
+
+fn inventory_path() -> String {
+    env::args().nth(1).unwrap_or_else(|| {
+        eprintln!("Usage: update_inventory <path/to/inventory.toml>");
+        process::exit(2);
+    })
 }

--- a/common/inventory-utils/src/upstream.rs
+++ b/common/inventory-utils/src/upstream.rs
@@ -54,12 +54,6 @@ where
     fn diff_inventory() {
         let path = inventory_path();
 
-        let upstream_artifacts: HashSet<Artifact<V>> = Self::list_upstream_artifacts()
-            .unwrap_or_else(|e| {
-                eprintln!("Failed to fetch upstream artifacts: {e}");
-                std::process::exit(1)
-            });
-
         let inventory_artifacts: HashSet<Artifact<V>> = Inventory::read(&path)
             .unwrap_or_else(|e| {
                 eprintln!("Error reading inventory at '{path}': {e}");
@@ -68,6 +62,12 @@ where
             .artifacts
             .into_iter()
             .collect();
+
+        let upstream_artifacts: HashSet<Artifact<V>> = Self::list_upstream_artifacts()
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to fetch upstream artifacts: {e}");
+                std::process::exit(1)
+            });
 
         [
             ("Added", &upstream_artifacts - &inventory_artifacts),

--- a/common/inventory-utils/src/upstream.rs
+++ b/common/inventory-utils/src/upstream.rs
@@ -4,7 +4,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::fmt::Display;
-use std::{fs, process};
+use std::{env, fs, process};
 
 // Todo: Refactor with a different name
 #[allow(clippy::module_name_repetitions)]
@@ -19,8 +19,14 @@ where
     /// Issues listing upstream artifacts will return an Error
     fn list_upstream_artifacts() -> Result<HashSet<Artifact<V>>, Self::Error>;
 
-    fn update_local(path: String) {
+    fn update_local() {
         // List available upstream release versions.
+
+        let path = env::args().nth(1).unwrap_or_else(|| {
+            eprintln!("Usage: update_inventory <path/to/inventory.toml>");
+            process::exit(2);
+        });
+
         let mut remote_artifacts: Vec<Artifact<V>> = Self::list_upstream_artifacts()
             .unwrap_or_else(|e| {
                 eprintln!("Failed to fetch upstream go versions: {e}");
@@ -47,7 +53,12 @@ where
         });
     }
 
-    fn diff_inventory(path: String) {
+    fn diff_inventory() {
+        let path = std::env::args().nth(1).unwrap_or_else(|| {
+            eprintln!("$ diff_inventory path/to/inventory.toml");
+            std::process::exit(1);
+        });
+
         let upstream_artifacts: HashSet<Artifact<V>> = Self::list_upstream_artifacts()
             .unwrap_or_else(|e| {
                 eprintln!("Failed to fetch upstream go versions: {e}");

--- a/common/inventory-utils/src/upstream.rs
+++ b/common/inventory-utils/src/upstream.rs
@@ -1,0 +1,86 @@
+use crate::inv::{Artifact, Inventory};
+use crate::vrs::Version;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::collections::HashSet;
+use std::fmt::Display;
+use std::{fs, process};
+
+// Todo: Refactor with a different name
+#[allow(clippy::module_name_repetitions)]
+pub trait UpstreamInventory<V>
+where
+    V: Version + DeserializeOwned + Serialize + Clone,
+{
+    type Error: Display;
+
+    /// # Errors
+    ///
+    /// Issues listing upstream artifacts will return an Error
+    fn list_upstream_artifacts() -> Result<HashSet<Artifact<V>>, Self::Error>;
+
+    fn update_local(path: String) {
+        // List available upstream release versions.
+        let mut remote_artifacts: Vec<Artifact<V>> = Self::list_upstream_artifacts()
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to fetch upstream go versions: {e}");
+                process::exit(4)
+            })
+            .into_iter()
+            .collect();
+
+        remote_artifacts.sort();
+        remote_artifacts.reverse();
+
+        let inventory = Inventory {
+            artifacts: remote_artifacts,
+        };
+
+        let toml = toml::to_string(&inventory).unwrap_or_else(|e| {
+            eprintln!("Error serializing inventory as toml: {e}");
+            process::exit(6);
+        });
+
+        fs::write(path, toml).unwrap_or_else(|e| {
+            eprintln!("Error writing inventory to file: {e}");
+            process::exit(7);
+        });
+    }
+
+    fn diff_inventory(path: String) {
+        let upstream_artifacts: HashSet<Artifact<V>> = Self::list_upstream_artifacts()
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to fetch upstream go versions: {e}");
+                std::process::exit(1)
+            });
+
+        let inventory_artifacts: HashSet<Artifact<V>> = Inventory::read(&path)
+            .unwrap_or_else(|e| {
+                eprintln!("Error reading inventory at '{path}': {e}");
+                std::process::exit(1);
+            })
+            .artifacts
+            .into_iter()
+            .collect();
+
+        [
+            ("Added", &upstream_artifacts - &inventory_artifacts),
+            ("Removed", &inventory_artifacts - &upstream_artifacts),
+        ]
+        .iter()
+        .filter(|(_, artifact_diff)| !artifact_diff.is_empty())
+        .for_each(|(action, artifacts)| {
+            let mut list: Vec<&Artifact<V>> = artifacts.iter().collect();
+            list.sort();
+            list.reverse();
+            println!(
+                "{} {}.",
+                action,
+                list.iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        });
+    }
+}

--- a/common/inventory-utils/src/upstream.rs
+++ b/common/inventory-utils/src/upstream.rs
@@ -19,8 +19,10 @@ where
     /// Issues listing upstream artifacts will return an Error
     fn list_upstream_artifacts() -> Result<HashSet<Artifact<V>>, Self::Error>;
 
-    /// Updates a local inventory.toml with versions published upstream.
-    fn update_local() {
+    /// Fetches upstream artifacts and updates local inventory. This function
+    /// will create (or overwrite) the inventory at the specified file path,
+    /// based solely on the artifacts listed by upstream.
+    fn pull() {
         let path = inventory_path();
 
         let mut remote_artifacts: Vec<Artifact<V>> = Self::list_upstream_artifacts()

--- a/common/inventory-utils/src/upstream.rs
+++ b/common/inventory-utils/src/upstream.rs
@@ -96,7 +96,10 @@ where
 
 fn inventory_path() -> String {
     env::args().nth(1).unwrap_or_else(|| {
-        eprintln!("Usage: update_inventory <path/to/inventory.toml>");
+        eprintln!(
+            "Usage: {} <path/to/inventory.toml>",
+            &env::args().next().expect("args to be > 0")
+        );
         process::exit(2);
     })
 }

--- a/common/inventory-utils/src/upstream.rs
+++ b/common/inventory-utils/src/upstream.rs
@@ -19,6 +19,7 @@ where
     /// Issues listing upstream artifacts will return an Error
     fn list_upstream_artifacts() -> Result<HashSet<Artifact<V>>, Self::Error>;
 
+    /// Updates a local inventory.toml with versions published upstream.
     fn update_local() {
         // List available upstream release versions.
 
@@ -53,6 +54,9 @@ where
         });
     }
 
+    /// Prints a human-readable software inventory difference. Useful
+    /// for generating commit messages and changelogs for automated inventory
+    /// updates.
     fn diff_inventory() {
         let path = std::env::args().nth(1).unwrap_or_else(|| {
             eprintln!("$ diff_inventory path/to/inventory.toml");

--- a/common/inventory-utils/src/upstream.rs
+++ b/common/inventory-utils/src/upstream.rs
@@ -30,7 +30,7 @@ where
 
         let mut remote_artifacts: Vec<Artifact<V>> = Self::list_upstream_artifacts()
             .unwrap_or_else(|e| {
-                eprintln!("Failed to fetch upstream go versions: {e}");
+                eprintln!("Failed to fetch upstream artifacts: {e}");
                 process::exit(4)
             })
             .into_iter()
@@ -54,9 +54,8 @@ where
         });
     }
 
-    /// Prints a human-readable software inventory difference. Useful
-    /// for generating commit messages and changelogs for automated inventory
-    /// updates.
+    /// Prints a human-readable inventory diff. Useful for generating
+    /// commit messages and changelogs for automated inventory updates.
     fn diff_inventory() {
         let path = std::env::args().nth(1).unwrap_or_else(|| {
             eprintln!("$ diff_inventory path/to/inventory.toml");
@@ -65,7 +64,7 @@ where
 
         let upstream_artifacts: HashSet<Artifact<V>> = Self::list_upstream_artifacts()
             .unwrap_or_else(|e| {
-                eprintln!("Failed to fetch upstream go versions: {e}");
+                eprintln!("Failed to fetch upstream artifacts: {e}");
                 std::process::exit(1)
             });
 

--- a/common/inventory-utils/src/upstream.rs
+++ b/common/inventory-utils/src/upstream.rs
@@ -52,10 +52,7 @@ where
     /// Prints a human-readable inventory diff. Useful for generating
     /// commit messages and changelogs for automated inventory updates.
     fn diff_inventory() {
-        let path = std::env::args().nth(1).unwrap_or_else(|| {
-            eprintln!("$ diff_inventory path/to/inventory.toml");
-            std::process::exit(1);
-        });
+        let path = inventory_path();
 
         let upstream_artifacts: HashSet<Artifact<V>> = Self::list_upstream_artifacts()
             .unwrap_or_else(|e| {

--- a/common/inventory-utils/src/upstream.rs
+++ b/common/inventory-utils/src/upstream.rs
@@ -51,9 +51,10 @@ where
         });
     }
 
-    /// Prints a human-readable inventory diff. Useful for generating
-    /// commit messages and changelogs for automated inventory updates.
-    fn diff_inventory() {
+    /// Prints a human-readable inventory diff between upstream and the
+    /// specified inventory path. Useful for generating commit messages
+    /// and changelogs for automated inventory updates.
+    fn print_diff() {
         let path = inventory_path();
 
         let inventory_artifacts: HashSet<Artifact<V>> = Inventory::read(&path)


### PR DESCRIPTION
[WIP - don't review just yet]

This PR builds on https://github.com/heroku/buildpacks-go/pull/246 and seeks to move `inventory.toml` maintenance utils to the shared library:

* It introduces an `UpstreamInventory` trait, with default implementations for the current `diff_inventory` and `update_inventory` functionality - that code is moved almost verbatim from their current implementations, facilitated by the changes made prior to this PR.
* Requires an `Inventory<Version>` specific implementation of the current `list_upstream_artifacts` function.
* This function is implemented by `Inventory<GoVersion>` to include the Go specific upstream release feed fetching and parsing logic.
* This allows for easy integration with external tools, such as GitHub actions, to automatically maintain `inventory.toml` files with useful commit messages.
* We may want to consider introducing more flexibility and improving the handling of CLI arguments in the future.