### PR TITLE
Share binary download functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,6 @@ version = "0.0.0"
 dependencies = [
  "heroku-inventory-utils",
  "regex",
- "semver",
  "serde",
  "thiserror",
  "ureq",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,16 +438,12 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 name = "heroku-go-buildpack"
 version = "0.0.0"
 dependencies = [
- "flate2",
  "heroku-go-utils",
  "heroku-inventory-utils",
  "libcnb",
  "libcnb-test",
  "libherokubuildpack",
  "serde",
- "sha2",
- "tar",
- "tempfile",
  "thiserror",
  "toml",
  "ureq",
@@ -469,10 +465,15 @@ dependencies = [
 name = "heroku-inventory-utils"
 version = "0.0.0"
 dependencies = [
+ "flate2",
  "semver",
  "serde",
+ "sha2",
+ "tar",
+ "tempfile",
  "thiserror",
  "toml",
+ "ureq",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ name = "heroku-inventory-utils"
 version = "0.0.0"
 dependencies = [
  "flate2",
+ "hex",
  "semver",
  "serde",
  "sha2",
@@ -475,6 +476,12 @@ dependencies = [
  "toml",
  "ureq",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"

--- a/buildpacks/go/Cargo.toml
+++ b/buildpacks/go/Cargo.toml
@@ -9,18 +9,14 @@ workspace = true
 [dependencies]
 heroku-go-utils = { path = "../../common/go-utils" }
 heroku-inventory-utils = { path = "../../common/inventory-utils" }
-flate2 = { version = "1", default-features = false, features = ["zlib"] }
 # libcnb has a much bigger impact on buildpack behaviour than any other dependencies,
 # so it's pinned to an exact version to isolate it from lockfile refreshes.
 libcnb = { version = "=0.19.0", features = ["trace"] }
 libherokubuildpack = { version = "=0.19.0", default-features = false, features = ["log"] }
 serde = "1"
-sha2 = "0.10"
-tar = { version = "0.4", default-features = false }
 thiserror = "1"
 toml = "0.8"
 ureq = { version = "2", features = ["json"] }
 
 [dev-dependencies]
 libcnb-test = "=0.19.0"
-tempfile = "3"

--- a/buildpacks/go/src/layers/dist.rs
+++ b/buildpacks/go/src/layers/dist.rs
@@ -51,14 +51,13 @@ impl Layer for DistLayer {
             "Installing {} from {}",
             self.artifact, self.artifact.url
         ));
-        tgz::fetch_strip_filter_extract_verify(
-            self.artifact.url.clone(),
-            "go",
-            ["bin", "src", "pkg", "go.env", "LICENSE"].into_iter(),
-            layer_path,
-            &self.artifact.checksum,
-        )
-        .map_err(DistLayerError::Tgz)?;
+        self.artifact
+            .fetch_strip_filter_extract_verify(
+                "go",
+                ["bin", "src", "pkg", "go.env", "LICENSE"].into_iter(),
+                layer_path,
+            )
+            .map_err(DistLayerError::Tgz)?;
 
         LayerResultBuilder::new(DistLayerMetadata::current(self))
             .env(

--- a/buildpacks/go/src/layers/dist.rs
+++ b/buildpacks/go/src/layers/dist.rs
@@ -1,6 +1,7 @@
-use crate::{tgz, GoBuildpack, GoBuildpackError};
+use crate::{GoBuildpack, GoBuildpackError};
 use heroku_go_utils::vrs::GoVersion;
 use heroku_inventory_utils::inv::Artifact;
+use heroku_inventory_utils::tgz;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};

--- a/buildpacks/go/src/layers/dist.rs
+++ b/buildpacks/go/src/layers/dist.rs
@@ -56,7 +56,7 @@ impl Layer for DistLayer {
             "go",
             ["bin", "src", "pkg", "go.env", "LICENSE"].into_iter(),
             layer_path,
-            &self.artifact.checksum.value,
+            &self.artifact.checksum,
         )
         .map_err(DistLayerError::Tgz)?;
 

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -2,7 +2,6 @@ mod cfg;
 mod cmd;
 mod layers;
 mod proc;
-mod tgz;
 
 use heroku_go_utils::vrs::{GoRequirement, GoVersion};
 use heroku_inventory_utils::inv::Inventory;
@@ -25,6 +24,7 @@ use std::path::Path;
 
 #[cfg(test)]
 use libcnb_test as _;
+use ureq as _;
 
 const INVENTORY: &str = include_str!("../inventory.toml");
 

--- a/common/go-utils/Cargo.toml
+++ b/common/go-utils/Cargo.toml
@@ -8,7 +8,6 @@ workspace = true
 
 [dependencies]
 regex = "1"
-semver = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 ureq = { version = "2", features = ["json"] }

--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -3,7 +3,6 @@ use heroku_inventory_utils::{
     vrs::{RequirementParseError, Version, VersionRequirement},
 };
 use regex::Regex;
-use semver;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -54,8 +53,6 @@ pub struct GoVersion(SemanticVersion);
 
 #[derive(thiserror::Error, Debug)]
 pub enum GoVersionParseError {
-    #[error("Couldn't parse go version: {0}")]
-    SemVer(#[from] semver::Error),
     #[error("Internal buildpack issue parsing go version regex: {0}")]
     Regex(#[from] regex::Error),
     #[error("Couldn't parse version. Unable to capture values from regex.")]

--- a/common/inventory-utils/Cargo.toml
+++ b/common/inventory-utils/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 toml = "0.8"
 sha2 = "0.10"
+hex = "0.4"
 tar = { version = "0.4", default-features = false }
 ureq = { version = "2", features = ["json"] }
 

--- a/common/inventory-utils/Cargo.toml
+++ b/common/inventory-utils/Cargo.toml
@@ -7,7 +7,14 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
+flate2 = { version = "1", default-features = false, features = ["zlib"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 toml = "0.8"
+sha2 = "0.10"
+tar = { version = "0.4", default-features = false }
+ureq = { version = "2", features = ["json"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/common/inventory-utils/src/checksum.rs
+++ b/common/inventory-utils/src/checksum.rs
@@ -51,7 +51,7 @@ impl Display for Algorithm {
 #[derive(Debug, PartialEq, Clone, Eq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct Checksum {
-    algorithm: Algorithm,
+    pub(crate) algorithm: Algorithm,
     pub value: String,
 }
 

--- a/common/inventory-utils/src/lib.rs
+++ b/common/inventory-utils/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod checksum;
 pub mod inv;
 pub mod semvrs;
+pub mod tgz;
 pub mod upstream;
 pub mod vrs;

--- a/common/inventory-utils/src/tgz.rs
+++ b/common/inventory-utils/src/tgz.rs
@@ -7,7 +7,7 @@ use std::{fs, io::Read, path::StripPrefixError};
 use tar::Archive;
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum Error {
+pub enum Error {
     #[error("HTTP error while fetching archive: {0}")]
     Http(#[from] Box<ureq::Error>),
 
@@ -41,7 +41,7 @@ pub(crate) enum Error {
 /// # Errors
 ///
 /// See `Error` for an enumeration of error scenarios.
-pub(crate) fn fetch_strip_filter_extract_verify<'a>(
+pub fn fetch_strip_filter_extract_verify<'a>(
     uri: impl AsRef<str>,
     strip_prefix: impl AsRef<str>,
     filter_prefixes: impl Iterator<Item = &'a str>,

--- a/common/inventory-utils/src/tgz.rs
+++ b/common/inventory-utils/src/tgz.rs
@@ -1,12 +1,12 @@
 use flate2::read::GzDecoder;
 use sha2::{
     digest::{generic_array::GenericArray, OutputSizeUser},
-    Digest, Sha256,
+    Digest,
 };
 use std::{fs, io::Read, path::StripPrefixError};
 use tar::Archive;
 
-use crate::checksum::Checksum;
+use crate::{inv::Artifact, vrs::Version};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -35,28 +35,20 @@ pub enum Error {
     Prefix(StripPrefixError),
 }
 
-/// Fetches a tarball from a url, strips component paths, filters path prefixes,
-/// extracts files to a location, and verifies a sha256 checksum. Care is taken
-/// not to write temporary files or read the entire contents into memory. In an
-/// error scenario, any archive contents already extracted will not be removed.
-///
-/// # Errors
-///
-/// See `Error` for an enumeration of error scenarios.
-pub fn fetch_strip_filter_extract_verify<'a>(
-    uri: impl AsRef<str>,
+pub(crate) fn fetch_strip_filter_extract_verify<'a, D: Digest, V: Version>(
+    artifact: &Artifact<V>,
     strip_prefix: impl AsRef<str>,
     filter_prefixes: impl Iterator<Item = &'a str>,
     dest_dir: impl AsRef<std::path::Path>,
-    checksum: &Checksum,
 ) -> Result<(), Error> {
-    let expected_digest = checksum.value.as_ref();
+    let expected_digest = artifact.checksum.value.as_ref();
     let destination = dest_dir.as_ref();
-    let body = ureq::get(uri.as_ref())
+    let body = ureq::get(artifact.url.as_ref())
         .call()
         .map_err(Box::new)?
         .into_reader();
-    let mut archive = Archive::new(GzDecoder::new(DigestingReader::new(body, Sha256::new())));
+
+    let mut archive = Archive::new(GzDecoder::new(DigestingReader::new(body, D::new())));
     let filters: Vec<&str> = filter_prefixes.into_iter().collect();
     for entry in archive.entries().map_err(Error::Entries)? {
         let mut file = entry.map_err(Error::Entry)?;
@@ -76,7 +68,7 @@ pub fn fetch_strip_filter_extract_verify<'a>(
             file.unpack(&path).map_err(Error::Unpack)?;
         }
     }
-    let actual_digest = format!("{:x}", archive.into_inner().into_inner().finalize());
+    let actual_digest = hex::encode(archive.into_inner().into_inner().finalize());
     (expected_digest == actual_digest)
         .then_some(())
         .ok_or_else(|| Error::Checksum(expected_digest.to_string(), actual_digest))
@@ -109,23 +101,40 @@ impl<R: Read, H: sha2::Digest> Read for DigestingReader<R, H> {
 
 #[cfg(test)]
 mod tests {
-    use crate::checksum::Algorithm;
+    use sha2::Sha256;
+
+    use crate::{
+        checksum::{Algorithm, Checksum},
+        inv::{Arch, Artifact, Os},
+        semvrs::SemanticVersion,
+    };
 
     use super::*;
 
-    #[test]
-    fn test_fetch_strip_filter_extract_verify() {
-        let dest = tempfile::tempdir().expect("Couldn't create test tmpdir");
-        fetch_strip_filter_extract_verify(
-            "https://mirrors.edge.kernel.org/pub/software/scm/git/git-0.01.tar.gz",
-            "git-0.01",
-            ["README"].into_iter(),
-            dest.path(),
-            &Checksum::new(
+    fn create_artifact() -> Artifact<SemanticVersion> {
+        Artifact::<SemanticVersion> {
+            version: SemanticVersion::parse("1.7.2").unwrap(),
+            os: Os::Linux,
+            arch: Arch::X86_64,
+            url: String::from(
+                "https://mirrors.edge.kernel.org/pub/software/scm/git/git-0.01.tar.gz",
+            ),
+            checksum: Checksum::new(
                 Algorithm::Sha256,
                 "9bdf8a4198b269c5cbe4263b1f581aae885170a6cb93339a2033cb468e57dcd3".to_string(),
             )
             .unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_fetch_strip_filter_extract_verify() {
+        let dest = tempfile::tempdir().expect("Couldn't create test tmpdir");
+        fetch_strip_filter_extract_verify::<Sha256, SemanticVersion>(
+            &create_artifact(),
+            "git-0.01",
+            ["README"].into_iter(),
+            dest.path(),
         )
         .expect("Expected to fetch, strip, filter, extract, and verify");
 


### PR DESCRIPTION
[WIP - don't review just yet]

This PR builds on https://github.com/heroku/buildpacks-go/pull/247 and moves the logic to fetch, extract, and verify upstream tarballs to the shared inventory. It does so by:

* Leveraging the `Artifact`’s `Checksum` value to call the `tgz::fetch_strip_filter_extract_verify` with the appropriate digest algorithm (currently supporting `sha256` and `sha512`).
* Implementing a convenience function for `Artifact` that minimizes the parameters required to use this functionality, and eliminates the risk of specifying the wrong digest algorithm.
    * The digest algorithm used is based on the algorithm previously set when the artifact is added to the inventory (and the length is validated at that time as well).