### PR TITLE
Reintroduce stacks into buildpack.toml for compatibility with pack

### DIFF
--- a/buildpacks/go/buildpack.toml
+++ b/buildpacks/go/buildpack.toml
@@ -12,6 +12,13 @@ clear-env = true
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
+# [[stacks]] is deprecated in Buildpack API 0.10, but is (unintentionally?)
+# required by `pack buildpack package`. The [[stacks]] table should be
+# removed when the issue (https://github.com/buildpacks/pack/issues/2047) is
+# resolved.
+[[stacks]]
+id = "*"
+
 [[targets]]
 os = "linux"
 arch = "arm64"


### PR DESCRIPTION
Our publish automation is broken as can be seen [here](https://github.com/heroku/buildpacks-go/actions/runs/8574984168). The issue is described in https://github.com/buildpacks/pack/issues/2047, but basically `pack buildpack package` will error without a `[[stacks]]` key. This has been fixed in https://github.com/buildpacks/pack/pull/2081, but it has not yet been released. 

This change reintroduces `stacks` into `buildpack.toml` so that `pack buildpack package` will work on this buildpack again. This is the same fix we applied in https://github.com/heroku/buildpacks-procfile/pull/210.