### PR TITLE
Use OCI compliant arch ids

### DIFF
--- a/buildpacks/go/inventory.toml
+++ b/buildpacks/go/inventory.toml
@@ -1,3415 +1,3415 @@
 [[artifacts]]
 version = "go1.22.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.22.2.linux-amd64.tar.gz"
 checksum = "sha256:5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471216a17"
 
 [[artifacts]]
 version = "go1.22.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.22.2.linux-arm64.tar.gz"
 checksum = "sha256:36e720b2d564980c162a48c7e97da2e407dfcc4239e1e58d98082dfa2486a0c1"
 
 [[artifacts]]
 version = "go1.22.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.22.1.linux-amd64.tar.gz"
 checksum = "sha256:aab8e15785c997ae20f9c88422ee35d962c4562212bb0f879d052a35c8307c7f"
 
 [[artifacts]]
 version = "go1.22.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.22.1.linux-arm64.tar.gz"
 checksum = "sha256:e56685a245b6a0c592fc4a55f0b7803af5b3f827aaa29feab1f40e491acf35b8"
 
 [[artifacts]]
 version = "go1.22.0"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.22.0.linux-amd64.tar.gz"
 checksum = "sha256:f6c8a87aa03b92c4b0bf3d558e28ea03006eb29db78917daec5cfb6ec1046265"
 
 [[artifacts]]
 version = "go1.22.0"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.22.0.linux-arm64.tar.gz"
 checksum = "sha256:6a63fef0e050146f275bf02a0896badfe77c11b6f05499bb647e7bd613a45a10"
 
 [[artifacts]]
 version = "go1.22rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.22rc2.linux-amd64.tar.gz"
 checksum = "sha256:f811e7ee8f6dee3d162179229f96a64a467c8c02a5687fac5ceaadcf3948c818"
 
 [[artifacts]]
 version = "go1.22rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.22rc2.linux-arm64.tar.gz"
 checksum = "sha256:bf18dc64a396948f97df79a3d73176dbaa7d69341256a1ff1067fd7ec5f79295"
 
 [[artifacts]]
 version = "go1.22rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.22rc1.linux-amd64.tar.gz"
 checksum = "sha256:fbe9d0585b9322d44008f6baf78b391b22f64294338c6ce2b9eb6040d6373c52"
 
 [[artifacts]]
 version = "go1.22rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.22rc1.linux-arm64.tar.gz"
 checksum = "sha256:d777d6bc3241bcd470603c3af896d1c60ed1d8cc718cf92d0a5d9035b149a827"
 
 [[artifacts]]
 version = "go1.21.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21.9.linux-amd64.tar.gz"
 checksum = "sha256:f76194c2dc607e0df4ed2e7b825b5847cb37e34fc70d780e2f6c7e805634a7ea"
 
 [[artifacts]]
 version = "go1.21.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21.9.linux-arm64.tar.gz"
 checksum = "sha256:4d169d9cf3dde1692b81c0fd9484fa28d8bc98f672d06bf9db9c75ada73c5fbc"
 
 [[artifacts]]
 version = "go1.21.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21.8.linux-amd64.tar.gz"
 checksum = "sha256:538b3b143dc7f32b093c8ffe0e050c260b57fc9d57a12c4140a639a8dd2b4e4f"
 
 [[artifacts]]
 version = "go1.21.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21.8.linux-arm64.tar.gz"
 checksum = "sha256:3c19113c686ffa142e9159de1594c952dee64d5464965142d222eab3a81f1270"
 
 [[artifacts]]
 version = "go1.21.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21.7.linux-amd64.tar.gz"
 checksum = "sha256:13b76a9b2a26823e53062fa841b07087d48ae2ef2936445dc34c4ae03293702c"
 
 [[artifacts]]
 version = "go1.21.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21.7.linux-arm64.tar.gz"
 checksum = "sha256:a9bc1ccedbfde059f25b3a2ad81ae4cdf21192ae207dfd3ccbbfe99c3749e233"
 
 [[artifacts]]
 version = "go1.21.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21.6.linux-amd64.tar.gz"
 checksum = "sha256:3f934f40ac360b9c01f616a9aa1796d227d8b0328bf64cb045c7b8c4ee9caea4"
 
 [[artifacts]]
 version = "go1.21.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21.6.linux-arm64.tar.gz"
 checksum = "sha256:e2e8aa88e1b5170a0d495d7d9c766af2b2b6c6925a8f8956d834ad6b4cacbd9a"
 
 [[artifacts]]
 version = "go1.21.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21.5.linux-amd64.tar.gz"
 checksum = "sha256:e2bc0b3e4b64111ec117295c088bde5f00eeed1567999ff77bc859d7df70078e"
 
 [[artifacts]]
 version = "go1.21.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21.5.linux-arm64.tar.gz"
 checksum = "sha256:841cced7ecda9b2014f139f5bab5ae31785f35399f236b8b3e75dff2a2978d96"
 
 [[artifacts]]
 version = "go1.21.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21.4.linux-amd64.tar.gz"
 checksum = "sha256:73cac0215254d0c7d1241fa40837851f3b9a8a742d0b54714cbdfb3feaf8f0af"
 
 [[artifacts]]
 version = "go1.21.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21.4.linux-arm64.tar.gz"
 checksum = "sha256:ce1983a7289856c3a918e1fd26d41e072cc39f928adfb11ba1896440849b95da"
 
 [[artifacts]]
 version = "go1.21.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21.3.linux-amd64.tar.gz"
 checksum = "sha256:1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8"
 
 [[artifacts]]
 version = "go1.21.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21.3.linux-arm64.tar.gz"
 checksum = "sha256:fc90fa48ae97ba6368eecb914343590bbb61b388089510d0c56c2dde52987ef3"
 
 [[artifacts]]
 version = "go1.21.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21.2.linux-amd64.tar.gz"
 checksum = "sha256:f5414a770e5e11c6e9674d4cd4dd1f4f630e176d1828d3427ea8ca4211eee90d"
 
 [[artifacts]]
 version = "go1.21.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21.2.linux-arm64.tar.gz"
 checksum = "sha256:23e208ca44a3cb46cd4308e48a27c714ddde9c8c34f2e4211dbca95b6d456554"
 
 [[artifacts]]
 version = "go1.21.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21.1.linux-amd64.tar.gz"
 checksum = "sha256:b3075ae1ce5dab85f89bc7905d1632de23ca196bd8336afd93fa97434cfa55ae"
 
 [[artifacts]]
 version = "go1.21.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21.1.linux-arm64.tar.gz"
 checksum = "sha256:7da1a3936a928fd0b2602ed4f3ef535b8cd1990f1503b8d3e1acc0fa0759c967"
 
 [[artifacts]]
 version = "go1.21.0"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21.0.linux-amd64.tar.gz"
 checksum = "sha256:d0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742"
 
 [[artifacts]]
 version = "go1.21.0"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21.0.linux-arm64.tar.gz"
 checksum = "sha256:f3d4548edf9b22f26bbd49720350bbfe59d75b7090a1a2bff1afad8214febaf3"
 
 [[artifacts]]
 version = "go1.21rc4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21rc4.linux-amd64.tar.gz"
 checksum = "sha256:c05c7b5030c4785dd3b4125bdb9eb631a840ea7347f4219b299de308021ac15b"
 
 [[artifacts]]
 version = "go1.21rc4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21rc4.linux-arm64.tar.gz"
 checksum = "sha256:35961f9151b865df9947bc1e154b6f490c2c7b3efae2b44d984abc3f8c9b2be2"
 
 [[artifacts]]
 version = "go1.21rc3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21rc3.linux-amd64.tar.gz"
 checksum = "sha256:b5e3a28d10ba1109cf0549237f2739284a0db2ce6bdc76cd03c4b26304c1a921"
 
 [[artifacts]]
 version = "go1.21rc3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21rc3.linux-arm64.tar.gz"
 checksum = "sha256:8891193758aed49daedff3f519b12f81e15a947170437a9109e3ff8c11d7f7e2"
 
 [[artifacts]]
 version = "go1.21rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.21rc2.linux-amd64.tar.gz"
 checksum = "sha256:8fe90332727c606019e80a7368e23f5e65ad59520e45ee4010692f15572e45c6"
 
 [[artifacts]]
 version = "go1.21rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.21rc2.linux-arm64.tar.gz"
 checksum = "sha256:30a6518ca5f816c0fef5b2cc16b960e999b98b16f7d69f995f74236cc00aa292"
 
 [[artifacts]]
 version = "go1.20.14"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.14.linux-amd64.tar.gz"
 checksum = "sha256:ff445e48af27f93f66bd949ae060d97991c83e11289009d311f25426258f9c44"
 
 [[artifacts]]
 version = "go1.20.14"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.14.linux-arm64.tar.gz"
 checksum = "sha256:2096507509a98782850d1f0669786c09727053e9fe3c92b03c0d96f48700282b"
 
 [[artifacts]]
 version = "go1.20.13"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.13.linux-amd64.tar.gz"
 checksum = "sha256:9a9d3dcae2b6a638b1f2e9bd4db08ffb39c10e55d9696914002742d90f0047b5"
 
 [[artifacts]]
 version = "go1.20.13"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.13.linux-arm64.tar.gz"
 checksum = "sha256:a2d811cef3c4fc77c01195622e637af0c2cf8b3814a95a0920cf2f83b6061d38"
 
 [[artifacts]]
 version = "go1.20.12"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.12.linux-amd64.tar.gz"
 checksum = "sha256:9c5d48c54dd8b0a3b2ef91b0f92a1190aa01f11d26e98033efa64c46a30bba7b"
 
 [[artifacts]]
 version = "go1.20.12"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.12.linux-arm64.tar.gz"
 checksum = "sha256:8afe8e3fb6972eaa2179ef0a71678c67f26509fab4f0f67c4b00f4cdfa92dc87"
 
 [[artifacts]]
 version = "go1.20.11"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.11.linux-amd64.tar.gz"
 checksum = "sha256:ef79a11aa095a08772d2a69e4f152f897c4e96ee297b0dc20264b7dec2961abe"
 
 [[artifacts]]
 version = "go1.20.11"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.11.linux-arm64.tar.gz"
 checksum = "sha256:7908a49c6ce9d48af9b5ba76ccaa0769da45d8b635259a01065b3739acef4ada"
 
 [[artifacts]]
 version = "go1.20.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.10.linux-amd64.tar.gz"
 checksum = "sha256:80d34f1fd74e382d86c2d6102e0e60d4318461a7c2f457ec1efc4042752d4248"
 
 [[artifacts]]
 version = "go1.20.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.10.linux-arm64.tar.gz"
 checksum = "sha256:fb3c7e15fc4413c5b81eb9f26dbd7cd4faedd5c720b30fa8e2ff77457f74cab6"
 
 [[artifacts]]
 version = "go1.20.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.9.linux-amd64.tar.gz"
 checksum = "sha256:8921369701afa749b07232d2c34d514510c32dbfd79c65adb379451b5f0d7216"
 
 [[artifacts]]
 version = "go1.20.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.9.linux-arm64.tar.gz"
 checksum = "sha256:da7fca78f85b90b495382cd74b2d0a1c0b6aaa200e7feb27ae7198352b2317fa"
 
 [[artifacts]]
 version = "go1.20.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.8.linux-amd64.tar.gz"
 checksum = "sha256:cc97c28d9c252fbf28f91950d830201aa403836cbed702a05932e63f7f0c7bc4"
 
 [[artifacts]]
 version = "go1.20.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.8.linux-arm64.tar.gz"
 checksum = "sha256:15ab379c6a2b0d086fe3e74be4599420e66549edf7426a300ee0f3809500f89e"
 
 [[artifacts]]
 version = "go1.20.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.7.linux-amd64.tar.gz"
 checksum = "sha256:f0a87f1bcae91c4b69f8dc2bc6d7e6bfcd7524fceec130af525058c0c17b1b44"
 
 [[artifacts]]
 version = "go1.20.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.7.linux-arm64.tar.gz"
 checksum = "sha256:44781ae3b153c3b07651d93b6bc554e835a36e2d72a696281c1e4dad9efffe43"
 
 [[artifacts]]
 version = "go1.20.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.6.linux-amd64.tar.gz"
 checksum = "sha256:b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1eb"
 
 [[artifacts]]
 version = "go1.20.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.6.linux-arm64.tar.gz"
 checksum = "sha256:4e15ab37556e979181a1a1cc60f6d796932223a0f5351d7c83768b356f84429b"
 
 [[artifacts]]
 version = "go1.20.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.5.linux-amd64.tar.gz"
 checksum = "sha256:d7ec48cde0d3d2be2c69203bc3e0a44de8660b9c09a6e85c4732a3f7dc442612"
 
 [[artifacts]]
 version = "go1.20.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.5.linux-arm64.tar.gz"
 checksum = "sha256:aa2fab0a7da20213ff975fa7876a66d47b48351558d98851b87d1cfef4360d09"
 
 [[artifacts]]
 version = "go1.20.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.4.linux-amd64.tar.gz"
 checksum = "sha256:698ef3243972a51ddb4028e4a1ac63dc6d60821bf18e59a807e051fee0a385bd"
 
 [[artifacts]]
 version = "go1.20.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.4.linux-arm64.tar.gz"
 checksum = "sha256:105889992ee4b1d40c7c108555222ca70ae43fccb42e20fbf1eebb822f5e72c6"
 
 [[artifacts]]
 version = "go1.20.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.3.linux-amd64.tar.gz"
 checksum = "sha256:979694c2c25c735755bf26f4f45e19e64e4811d661dd07b8c010f7a8e18adfca"
 
 [[artifacts]]
 version = "go1.20.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.3.linux-arm64.tar.gz"
 checksum = "sha256:eb186529f13f901e7a2c4438a05c2cd90d74706aaa0a888469b2a4a617b6ee54"
 
 [[artifacts]]
 version = "go1.20.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.2.linux-amd64.tar.gz"
 checksum = "sha256:4eaea32f59cde4dc635fbc42161031d13e1c780b87097f4b4234cfce671f1768"
 
 [[artifacts]]
 version = "go1.20.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.2.linux-arm64.tar.gz"
 checksum = "sha256:78d632915bb75e9a6356a47a42625fd1a785c83a64a643fedd8f61e31b1b3bef"
 
 [[artifacts]]
 version = "go1.20.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.1.linux-amd64.tar.gz"
 checksum = "sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02"
 
 [[artifacts]]
 version = "go1.20.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.1.linux-arm64.tar.gz"
 checksum = "sha256:5e5e2926733595e6f3c5b5ad1089afac11c1490351855e87849d0e7702b1ec2e"
 
 [[artifacts]]
 version = "go1.20"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20.linux-amd64.tar.gz"
 checksum = "sha256:5a9ebcc65c1cce56e0d2dc616aff4c4cedcfbda8cc6f0288cc08cda3b18dcbf1"
 
 [[artifacts]]
 version = "go1.20"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20.linux-arm64.tar.gz"
 checksum = "sha256:17700b6e5108e2a2c3b1a43cd865d3f9c66b7f1c5f0cec26d3672cc131cc0994"
 
 [[artifacts]]
 version = "go1.20rc3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20rc3.linux-amd64.tar.gz"
 checksum = "sha256:a53434fa355bcae0cd02796690715b08ebe1c3f33d384d83cf155842fd6856ba"
 
 [[artifacts]]
 version = "go1.20rc3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20rc3.linux-arm64.tar.gz"
 checksum = "sha256:8cf0b9091e9bc3961e62395b1fc8e647f5359ffee30b980658ea7ca193e08ce5"
 
 [[artifacts]]
 version = "go1.20rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20rc2.linux-amd64.tar.gz"
 checksum = "sha256:9ba01a3be1a682b89f5bfc62f9fba0e7d6990a5b7018f6c7aaa56ad65ed96a0e"
 
 [[artifacts]]
 version = "go1.20rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20rc2.linux-arm64.tar.gz"
 checksum = "sha256:d14c1eeb9f48e8def6f886f4cdec57c0a90ba47bdee1b79a00543aa30386e3a6"
 
 [[artifacts]]
 version = "go1.20rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.20rc1.linux-amd64.tar.gz"
 checksum = "sha256:4757fb32d7514145e43d4f37713f98d8cc0ecbbb5b1737accfc84be50e1e2e32"
 
 [[artifacts]]
 version = "go1.20rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.20rc1.linux-arm64.tar.gz"
 checksum = "sha256:dfc64ba011710565821cc97a2685c5afe3b9cbd5a3e3b665ffb3384d15c5ae50"
 
 [[artifacts]]
 version = "go1.19.13"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.13.linux-amd64.tar.gz"
 checksum = "sha256:4643d4c29c55f53fa0349367d7f1bb5ca554ea6ef528c146825b0f8464e2e668"
 
 [[artifacts]]
 version = "go1.19.13"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.13.linux-arm64.tar.gz"
 checksum = "sha256:1142ada7bba786d299812b23edd446761a54efbbcde346c2f0bc69ca6a007b58"
 
 [[artifacts]]
 version = "go1.19.12"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.12.linux-amd64.tar.gz"
 checksum = "sha256:48e4fcfb6abfdaa01aaf1429e43bdd49cea5e4687bd5f5b96df1e193fcfd3e7e"
 
 [[artifacts]]
 version = "go1.19.12"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.12.linux-arm64.tar.gz"
 checksum = "sha256:18da7cf1ae5341e6ee120948221aff96df9145ce70f429276514ca7c67c929b1"
 
 [[artifacts]]
 version = "go1.19.11"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.11.linux-amd64.tar.gz"
 checksum = "sha256:ee18f98a03386e2bf48ff75737ea17c953b1572f9b1114352f104ac5eef04bb4"
 
 [[artifacts]]
 version = "go1.19.11"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.11.linux-arm64.tar.gz"
 checksum = "sha256:ae22c047e0e63d2d28205b529baaf9d9ca0c93e890c309af62cd116b9efebcbd"
 
 [[artifacts]]
 version = "go1.19.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.10.linux-amd64.tar.gz"
 checksum = "sha256:8b045a483d3895c6edba2e90a9189262876190dbbd21756870cdd63821810677"
 
 [[artifacts]]
 version = "go1.19.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.10.linux-arm64.tar.gz"
 checksum = "sha256:df98698821211c819e8b2420c77a0f802d989e377718578a31b1f91f6be2c5b4"
 
 [[artifacts]]
 version = "go1.19.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.9.linux-amd64.tar.gz"
 checksum = "sha256:e858173b489ec1ddbe2374894f52f53e748feed09dde61be5b4b4ba2d73ef34b"
 
 [[artifacts]]
 version = "go1.19.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.9.linux-arm64.tar.gz"
 checksum = "sha256:b947e457be9d7b52a082c68e42b6939f9cc151f1ad5b3d8fd646ca3352f6f2f1"
 
 [[artifacts]]
 version = "go1.19.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.8.linux-amd64.tar.gz"
 checksum = "sha256:e1a0bf0ab18c8218805a1003fd702a41e2e807710b770e787e5979d1cf947aba"
 
 [[artifacts]]
 version = "go1.19.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.8.linux-arm64.tar.gz"
 checksum = "sha256:f89e7c0ba63782143bd1f896e4b96ea09e4baf39e8bc2f2ddf27339f9e433dd3"
 
 [[artifacts]]
 version = "go1.19.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.7.linux-amd64.tar.gz"
 checksum = "sha256:7a75720c9b066ae1750f6bcc7052aba70fa3813f4223199ee2a2315fd3eb533d"
 
 [[artifacts]]
 version = "go1.19.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.7.linux-arm64.tar.gz"
 checksum = "sha256:071ea7bf386fdd08df524859b878d99fc359e491e7ad65c1c1cc55b67972c882"
 
 [[artifacts]]
 version = "go1.19.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.6.linux-amd64.tar.gz"
 checksum = "sha256:e3410c676ced327aec928303fef11385702a5562fd19d9a1750d5a2979763c3d"
 
 [[artifacts]]
 version = "go1.19.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.6.linux-arm64.tar.gz"
 checksum = "sha256:e4d63c933a68e5fad07cab9d12c5c1610ce4810832d47c44314c3246f511ac4f"
 
 [[artifacts]]
 version = "go1.19.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.5.linux-amd64.tar.gz"
 checksum = "sha256:36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95"
 
 [[artifacts]]
 version = "go1.19.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.5.linux-arm64.tar.gz"
 checksum = "sha256:fc0aa29c933cec8d76f5435d859aaf42249aa08c74eb2d154689ae44c08d23b3"
 
 [[artifacts]]
 version = "go1.19.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.4.linux-amd64.tar.gz"
 checksum = "sha256:c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8"
 
 [[artifacts]]
 version = "go1.19.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.4.linux-arm64.tar.gz"
 checksum = "sha256:9df122d6baf6f2275270306b92af3b09d7973fb1259257e284dba33c0db14f1b"
 
 [[artifacts]]
 version = "go1.19.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.3.linux-amd64.tar.gz"
 checksum = "sha256:74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba"
 
 [[artifacts]]
 version = "go1.19.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.3.linux-arm64.tar.gz"
 checksum = "sha256:99de2fe112a52ab748fb175edea64b313a0c8d51d6157dba683a6be163fd5eab"
 
 [[artifacts]]
 version = "go1.19.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.2.linux-amd64.tar.gz"
 checksum = "sha256:5e8c5a74fe6470dd7e055a461acda8bb4050ead8c2df70f227e3ff7d8eb7eeb6"
 
 [[artifacts]]
 version = "go1.19.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.2.linux-arm64.tar.gz"
 checksum = "sha256:b62a8d9654436c67c14a0c91e931d50440541f09eb991a987536cb982903126d"
 
 [[artifacts]]
 version = "go1.19.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.1.linux-amd64.tar.gz"
 checksum = "sha256:acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde"
 
 [[artifacts]]
 version = "go1.19.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.1.linux-arm64.tar.gz"
 checksum = "sha256:49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f"
 
 [[artifacts]]
 version = "go1.19"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19.linux-amd64.tar.gz"
 checksum = "sha256:464b6b66591f6cf055bc5df90a9750bf5fbc9d038722bb84a9d56a2bea974be6"
 
 [[artifacts]]
 version = "go1.19"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19.linux-arm64.tar.gz"
 checksum = "sha256:efa97fac9574fc6ef6c9ff3e3758fb85f1439b046573bf434cccb5e012bd00c8"
 
 [[artifacts]]
 version = "go1.19rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19rc2.linux-amd64.tar.gz"
 checksum = "sha256:9130c6f8e87ce9bb4813533a68c3f17c82c7307caf8795d3c9427652b77f81aa"
 
 [[artifacts]]
 version = "go1.19rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19rc2.linux-arm64.tar.gz"
 checksum = "sha256:9260d3d8db973e2afd0b53f70ebb2f977f3716660de02a0ca4a14667fab2c658"
 
 [[artifacts]]
 version = "go1.19rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19rc1.linux-amd64.tar.gz"
 checksum = "sha256:6dce5b8784149dc983ad809f6a185356ebdd143aaf3df90a942d29ccd2267303"
 
 [[artifacts]]
 version = "go1.19rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19rc1.linux-arm64.tar.gz"
 checksum = "sha256:c4bd18d8df6d7d4f22d9ae77cebdba02b3671adedc7036961a6617a621f23769"
 
 [[artifacts]]
 version = "go1.19beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.19beta1.linux-amd64.tar.gz"
 checksum = "sha256:7d4df5bb5f94acf23edeb5a87f962696e6c6a2ea0b58280433deea79f9a231d3"
 
 [[artifacts]]
 version = "go1.19beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.19beta1.linux-arm64.tar.gz"
 checksum = "sha256:b4dc2ddcc6e93488a8d23e155ba2a7501e754f5991289ecba33b3c5a52946bea"
 
 [[artifacts]]
 version = "go1.18.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.10.linux-amd64.tar.gz"
 checksum = "sha256:5e05400e4c79ef5394424c0eff5b9141cb782da25f64f79d54c98af0a37f8d49"
 
 [[artifacts]]
 version = "go1.18.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.10.linux-arm64.tar.gz"
 checksum = "sha256:160497c583d4c7cbc1661230e68b758d01f741cf4bece67e48edc4fdd40ed92d"
 
 [[artifacts]]
 version = "go1.18.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.9.linux-amd64.tar.gz"
 checksum = "sha256:015692d2a48e3496f1da3328cf33337c727c595011883f6fc74f9b5a9c86ffa8"
 
 [[artifacts]]
 version = "go1.18.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.9.linux-arm64.tar.gz"
 checksum = "sha256:ae21430756c69c48201c51c3a17ac785613d9616105959a0fb7592e407be8588"
 
 [[artifacts]]
 version = "go1.18.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.8.linux-amd64.tar.gz"
 checksum = "sha256:4d854c7bad52d53470cf32f1b287a5c0c441dc6b98306dea27358e099698142a"
 
 [[artifacts]]
 version = "go1.18.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.8.linux-arm64.tar.gz"
 checksum = "sha256:df71bc84d84f7f62dad06aca5e1b8234045dce94a94dcefe71af0cb8f6e93a87"
 
 [[artifacts]]
 version = "go1.18.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.7.linux-amd64.tar.gz"
 checksum = "sha256:6c967efc22152ce3124fc35cdf50fc686870120c5fd2107234d05d450a6105d8"
 
 [[artifacts]]
 version = "go1.18.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.7.linux-arm64.tar.gz"
 checksum = "sha256:dceea023a9f87dc7c3bf638874e34ff1b42b76e3f1e489510a0c5ffde0cad438"
 
 [[artifacts]]
 version = "go1.18.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.6.linux-amd64.tar.gz"
 checksum = "sha256:bb05f179a773fed60c6a454a24141aaa7e71edfd0f2d465ad610a3b8f1dc7fe8"
 
 [[artifacts]]
 version = "go1.18.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.6.linux-arm64.tar.gz"
 checksum = "sha256:838ffa94158125f16e4aa667ee4f6b499ea57e3e35a7e2517ad357ea06714691"
 
 [[artifacts]]
 version = "go1.18.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.5.linux-amd64.tar.gz"
 checksum = "sha256:9e5de37f9c49942c601b191ac5fba404b868bfc21d446d6960acc12283d6e5f2"
 
 [[artifacts]]
 version = "go1.18.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.5.linux-arm64.tar.gz"
 checksum = "sha256:006f6622718212363fa1ff004a6ab4d87bbbe772ec5631bab7cac10be346e4f1"
 
 [[artifacts]]
 version = "go1.18.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.4.linux-amd64.tar.gz"
 checksum = "sha256:c9b099b68d93f5c5c8a8844a89f8db07eaa58270e3a1e01804f17f4cf8df02f5"
 
 [[artifacts]]
 version = "go1.18.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.4.linux-arm64.tar.gz"
 checksum = "sha256:35014d92b50d97da41dade965df7ebeb9a715da600206aa59ce1b2d05527421f"
 
 [[artifacts]]
 version = "go1.18.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
 checksum = "sha256:956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245"
 
 [[artifacts]]
 version = "go1.18.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.3.linux-arm64.tar.gz"
 checksum = "sha256:beacbe1441bee4d7978b900136d1d6a71d150f0a9bb77e9d50c822065623a35a"
 
 [[artifacts]]
 version = "go1.18.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.2.linux-amd64.tar.gz"
 checksum = "sha256:e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc"
 
 [[artifacts]]
 version = "go1.18.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.2.linux-arm64.tar.gz"
 checksum = "sha256:fc4ad28d0501eaa9c9d6190de3888c9d44d8b5fb02183ce4ae93713f67b8a35b"
 
 [[artifacts]]
 version = "go1.18.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.1.linux-amd64.tar.gz"
 checksum = "sha256:b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334"
 
 [[artifacts]]
 version = "go1.18.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.1.linux-arm64.tar.gz"
 checksum = "sha256:56a91851c97fb4697077abbca38860f735c32b38993ff79b088dac46e4735633"
 
 [[artifacts]]
 version = "go1.18"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18.linux-amd64.tar.gz"
 checksum = "sha256:e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f"
 
 [[artifacts]]
 version = "go1.18"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18.linux-arm64.tar.gz"
 checksum = "sha256:7ac7b396a691e588c5fb57687759e6c4db84a2a3bbebb0765f4b38e5b1c5b00e"
 
 [[artifacts]]
 version = "go1.18rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18rc1.linux-amd64.tar.gz"
 checksum = "sha256:9ea4e6adee711e06fa95546e1a9629b63de3aaae85fac9dc752fb533f3e5be23"
 
 [[artifacts]]
 version = "go1.18rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18rc1.linux-arm64.tar.gz"
 checksum = "sha256:e4528a113016872a3715cec37a6c6dad36d76d51a50fa19b33b7673e47e6df44"
 
 [[artifacts]]
 version = "go1.18beta2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18beta2.linux-amd64.tar.gz"
 checksum = "sha256:b5dacafa59737cfb0d657902b70c2ad1b6bb4ed15e85ea2806f72ce3d4824688"
 
 [[artifacts]]
 version = "go1.18beta2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18beta2.linux-arm64.tar.gz"
 checksum = "sha256:21e4248594401568c2e8704b9d26c6185a61f46b4f17e1a628bf1b5d9a010503"
 
 [[artifacts]]
 version = "go1.18beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.18beta1.linux-amd64.tar.gz"
 checksum = "sha256:128f72c5c22640085e4187cd1b540c587cf8fb280f941519bd2d1ae9fdab4f37"
 
 [[artifacts]]
 version = "go1.18beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.18beta1.linux-arm64.tar.gz"
 checksum = "sha256:717092a7265a86af2454cd402b29e8889fb1c83971220fbc37946755e14c891a"
 
 [[artifacts]]
 version = "go1.17.13"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.13.linux-amd64.tar.gz"
 checksum = "sha256:4cdd2bc664724dc7db94ad51b503512c5ae7220951cac568120f64f8e94399fc"
 
 [[artifacts]]
 version = "go1.17.13"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.13.linux-arm64.tar.gz"
 checksum = "sha256:914daad3f011cc2014dea799bb7490442677e4ad6de0b2ac3ded6cee7e3f493d"
 
 [[artifacts]]
 version = "go1.17.12"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.12.linux-amd64.tar.gz"
 checksum = "sha256:6e5203fbdcade4aa4331e441fd2e1db8444681a6a6c72886a37ddd11caa415d4"
 
 [[artifacts]]
 version = "go1.17.12"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.12.linux-arm64.tar.gz"
 checksum = "sha256:74a4832d0f150a2d768a6781553494ba84152e854ebef743c4092cd9d1f66a9f"
 
 [[artifacts]]
 version = "go1.17.11"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.11.linux-amd64.tar.gz"
 checksum = "sha256:d69a4fe2694f795d8e525c72b497ededc209cb7185f4c3b62d7a98dd6227b3fe"
 
 [[artifacts]]
 version = "go1.17.11"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.11.linux-arm64.tar.gz"
 checksum = "sha256:adefa7412c6798f9cad02d1e8336fc2242f5bade30c5b32781759181e01961b7"
 
 [[artifacts]]
 version = "go1.17.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.10.linux-amd64.tar.gz"
 checksum = "sha256:87fc728c9c731e2f74e4a999ef53cf07302d7ed3504b0839027bd9c10edaa3fd"
 
 [[artifacts]]
 version = "go1.17.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.10.linux-arm64.tar.gz"
 checksum = "sha256:649141201efa7195403eb1301b95dc79c5b3e65968986a391da1370521701b0c"
 
 [[artifacts]]
 version = "go1.17.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.9.linux-amd64.tar.gz"
 checksum = "sha256:9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6"
 
 [[artifacts]]
 version = "go1.17.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.9.linux-arm64.tar.gz"
 checksum = "sha256:44dcdcd4f0fa6f83c15ef70b31580f1e3f95895c2f11a00e36c440c3554b6ad5"
 
 [[artifacts]]
 version = "go1.17.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.8.linux-amd64.tar.gz"
 checksum = "sha256:980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99"
 
 [[artifacts]]
 version = "go1.17.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.8.linux-arm64.tar.gz"
 checksum = "sha256:57a9171682e297df1a5bd287be056ed0280195ad079af90af16dcad4f64710cb"
 
 [[artifacts]]
 version = "go1.17.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.7.linux-amd64.tar.gz"
 checksum = "sha256:02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259"
 
 [[artifacts]]
 version = "go1.17.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.7.linux-arm64.tar.gz"
 checksum = "sha256:a5aa1ed17d45ee1d58b4a4099b12f8942acbd1dd09b2e9a6abb1c4898043c5f5"
 
 [[artifacts]]
 version = "go1.17.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.6.linux-amd64.tar.gz"
 checksum = "sha256:231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2"
 
 [[artifacts]]
 version = "go1.17.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.6.linux-arm64.tar.gz"
 checksum = "sha256:82c1a033cce9bc1b47073fd6285233133040f0378439f3c4659fe77cc534622a"
 
 [[artifacts]]
 version = "go1.17.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.5.linux-amd64.tar.gz"
 checksum = "sha256:bd78114b0d441b029c8fe0341f4910370925a4d270a6a590668840675b0c653e"
 
 [[artifacts]]
 version = "go1.17.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.5.linux-arm64.tar.gz"
 checksum = "sha256:6f95ce3da40d9ce1355e48f31f4eb6508382415ca4d7413b1e7a3314e6430e7e"
 
 [[artifacts]]
 version = "go1.17.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.4.linux-amd64.tar.gz"
 checksum = "sha256:adab2483f644e2f8a10ae93122f0018cef525ca48d0b8764dae87cb5f4fd4206"
 
 [[artifacts]]
 version = "go1.17.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.4.linux-arm64.tar.gz"
 checksum = "sha256:617a46bd083e59877bb5680998571b3ddd4f6dcdaf9f8bf65ad4edc8f3eafb13"
 
 [[artifacts]]
 version = "go1.17.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.3.linux-amd64.tar.gz"
 checksum = "sha256:550f9845451c0c94be679faf116291e7807a8d78b43149f9506c1b15eb89008c"
 
 [[artifacts]]
 version = "go1.17.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.3.linux-arm64.tar.gz"
 checksum = "sha256:06f505c8d27203f78706ad04e47050b49092f1b06dc9ac4fbee4f0e4d015c8d4"
 
 [[artifacts]]
 version = "go1.17.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.2.linux-amd64.tar.gz"
 checksum = "sha256:f242a9db6a0ad1846de7b6d94d507915d14062660616a61ef7c808a76e4f1676"
 
 [[artifacts]]
 version = "go1.17.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.2.linux-arm64.tar.gz"
 checksum = "sha256:a5a43c9cdabdb9f371d56951b14290eba8ce2f9b0db48fb5fc657943984fd4fc"
 
 [[artifacts]]
 version = "go1.17.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.1.linux-amd64.tar.gz"
 checksum = "sha256:dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef"
 
 [[artifacts]]
 version = "go1.17.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.1.linux-arm64.tar.gz"
 checksum = "sha256:53b29236fa03ed862670a5e5e2ab2439a2dc288fe61544aa392062104ac0128c"
 
 [[artifacts]]
 version = "go1.17"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17.linux-amd64.tar.gz"
 checksum = "sha256:6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d"
 
 [[artifacts]]
 version = "go1.17"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17.linux-arm64.tar.gz"
 checksum = "sha256:01a9af009ada22122d3fcb9816049c1d21842524b38ef5d5a0e2ee4b26d7c3e7"
 
 [[artifacts]]
 version = "go1.17rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17rc2.linux-amd64.tar.gz"
 checksum = "sha256:328235edc7c7d2a51d6c6cb4d7ff97e97357654ef9e1098b9a4603a9d278ad04"
 
 [[artifacts]]
 version = "go1.17rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17rc2.linux-arm64.tar.gz"
 checksum = "sha256:4e1b335c53bf28cd20c5f7f2f7e79187b93e71c1d027448e313097785efb673d"
 
 [[artifacts]]
 version = "go1.17rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17rc1.linux-amd64.tar.gz"
 checksum = "sha256:bfbd3881a01ca3826777b1c40f241acacd45b14730d373259cd673d74e15e534"
 
 [[artifacts]]
 version = "go1.17rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17rc1.linux-arm64.tar.gz"
 checksum = "sha256:7498e426ce814a94a1d271d6bb80b9a2cf8c77ec49df531c57bd7a9ff82cfa4e"
 
 [[artifacts]]
 version = "go1.17beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.17beta1.linux-amd64.tar.gz"
 checksum = "sha256:a479681705b65971f9db079bfce53c4393bfa241d952eb09de88fb40677d3c4c"
 
 [[artifacts]]
 version = "go1.17beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.17beta1.linux-arm64.tar.gz"
 checksum = "sha256:ede56f79c5061146929ab4a128e8ee7bc713d141e87b3df4e0aa670938e128b3"
 
 [[artifacts]]
 version = "go1.16.15"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.15.linux-amd64.tar.gz"
 checksum = "sha256:77c782a633186d78c384f972fb113a43c24be0234c42fef22c2d8c4c4c8e7475"
 
 [[artifacts]]
 version = "go1.16.15"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.15.linux-arm64.tar.gz"
 checksum = "sha256:c2f27f0ce5620a9bc2ff3446165d1974ef94e9b885ec12dbfa3c07e0e198b7ce"
 
 [[artifacts]]
 version = "go1.16.14"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.14.linux-amd64.tar.gz"
 checksum = "sha256:f4f5f02eb6809ac5bf19b5ad517b23504fd5fc036f6487651968ad36aa7a20e0"
 
 [[artifacts]]
 version = "go1.16.14"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.14.linux-arm64.tar.gz"
 checksum = "sha256:5e59056e36704acb25809bcdb27191f27593cb7aba4d716b523008135a1e764a"
 
 [[artifacts]]
 version = "go1.16.13"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.13.linux-amd64.tar.gz"
 checksum = "sha256:275fc03c90c13b0bbff13125a43f1f7a9f9c00a0d5a9f2d5b16dbc2fa2c6e12a"
 
 [[artifacts]]
 version = "go1.16.13"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.13.linux-arm64.tar.gz"
 checksum = "sha256:3dd8e14837105cbfedf7124c7f8c524ce492748c370036c7316ef99e18d116d7"
 
 [[artifacts]]
 version = "go1.16.12"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.12.linux-amd64.tar.gz"
 checksum = "sha256:7d657e86493ac1d5892f340a7d88b862b12edb5ac6e73c099e8e0668a6c916b7"
 
 [[artifacts]]
 version = "go1.16.12"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.12.linux-arm64.tar.gz"
 checksum = "sha256:7dbf50ab2e665ecd6c86a3f1ce8c04f7167f9895b91921e25cf1bdc1cb9b5fd7"
 
 [[artifacts]]
 version = "go1.16.11"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.11.linux-amd64.tar.gz"
 checksum = "sha256:aa22d0e2be68c0a7027a64e76cbb2869332fbc42ce14e3d10b69007b51030775"
 
 [[artifacts]]
 version = "go1.16.11"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.11.linux-arm64.tar.gz"
 checksum = "sha256:64c91efd14304174c6e796e84543b896b2ae855aaf2ce0237efd32f2079cdcb8"
 
 [[artifacts]]
 version = "go1.16.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.10.linux-amd64.tar.gz"
 checksum = "sha256:414cd18ce1d193769b9e97d2401ad718755ab47816e13b2a1cde203d263b55cf"
 
 [[artifacts]]
 version = "go1.16.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.10.linux-arm64.tar.gz"
 checksum = "sha256:bfe1d4b82626c742b4690a832ca59a21e3d702161556f3c0ed26dffb368927e9"
 
 [[artifacts]]
 version = "go1.16.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.9.linux-amd64.tar.gz"
 checksum = "sha256:d2c095c95f63c2a3ef961000e0ecb9d81d5c68b6ece176e2a8a2db82dc02931c"
 
 [[artifacts]]
 version = "go1.16.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.9.linux-arm64.tar.gz"
 checksum = "sha256:92b3c4051b9388181d2fedf498a4137ca5cc17550c69f96418a434f8baca3ccf"
 
 [[artifacts]]
 version = "go1.16.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.8.linux-amd64.tar.gz"
 checksum = "sha256:f32501aeb8b7b723bc7215f6c373abb6981bbc7e1c7b44e9f07317e1a300dce2"
 
 [[artifacts]]
 version = "go1.16.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.8.linux-arm64.tar.gz"
 checksum = "sha256:430dbe185417204f6788913197ab3b189b6deae9c9b524f262858e53dab239c2"
 
 [[artifacts]]
 version = "go1.16.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.7.linux-amd64.tar.gz"
 checksum = "sha256:7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04"
 
 [[artifacts]]
 version = "go1.16.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.7.linux-arm64.tar.gz"
 checksum = "sha256:63d6b53ecbd2b05c1f0e9903c92042663f2f68afdbb67f4d0d12700156869bac"
 
 [[artifacts]]
 version = "go1.16.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.6.linux-amd64.tar.gz"
 checksum = "sha256:be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
 
 [[artifacts]]
 version = "go1.16.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.6.linux-arm64.tar.gz"
 checksum = "sha256:9e38047463da6daecab9017cd0599f33f84991e68263752cfab49253bbc98c30"
 
 [[artifacts]]
 version = "go1.16.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.5.linux-amd64.tar.gz"
 checksum = "sha256:b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061"
 
 [[artifacts]]
 version = "go1.16.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.5.linux-arm64.tar.gz"
 checksum = "sha256:d5446b46ef6f36fdffa852f73dfbbe78c1ddf010b99fa4964944b9ae8b4d6799"
 
 [[artifacts]]
 version = "go1.16.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.4.linux-amd64.tar.gz"
 checksum = "sha256:7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59"
 
 [[artifacts]]
 version = "go1.16.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.4.linux-arm64.tar.gz"
 checksum = "sha256:8b18eb05ddda2652d69ab1b1dd1f40dd731799f43c6a58b512ad01ae5b5bba21"
 
 [[artifacts]]
 version = "go1.16.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.3.linux-amd64.tar.gz"
 checksum = "sha256:951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2"
 
 [[artifacts]]
 version = "go1.16.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.3.linux-arm64.tar.gz"
 checksum = "sha256:566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d"
 
 [[artifacts]]
 version = "go1.16.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.2.linux-amd64.tar.gz"
 checksum = "sha256:542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8"
 
 [[artifacts]]
 version = "go1.16.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.2.linux-arm64.tar.gz"
 checksum = "sha256:6924601d998a0917694fd14261347e3798bd2ad6b13c4d7f2edd70c9d57f62ab"
 
 [[artifacts]]
 version = "go1.16.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.1.linux-amd64.tar.gz"
 checksum = "sha256:3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769"
 
 [[artifacts]]
 version = "go1.16.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.1.linux-arm64.tar.gz"
 checksum = "sha256:fa8a6034e51e5cceaa477027d44c2f9a2f1d9540e8ce881014c526c11290a180"
 
 [[artifacts]]
 version = "go1.16"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16.linux-amd64.tar.gz"
 checksum = "sha256:013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"
 
 [[artifacts]]
 version = "go1.16"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16.linux-arm64.tar.gz"
 checksum = "sha256:3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098"
 
 [[artifacts]]
 version = "go1.16rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16rc1.linux-amd64.tar.gz"
 checksum = "sha256:6a62610f56a04bae8702cd2bd73bfea34645c1b89ded3f0b81a841393b6f1f14"
 
 [[artifacts]]
 version = "go1.16rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16rc1.linux-arm64.tar.gz"
 checksum = "sha256:ba6769f0e2051fcb5418c4ba9b3f12fe7776f865e8ae8692d71efed74c4373fa"
 
 [[artifacts]]
 version = "go1.16beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.16beta1.linux-amd64.tar.gz"
 checksum = "sha256:3931a0d493d411d6c697df6f15d5292fdd8031fde7014fded399effdad4c12d8"
 
 [[artifacts]]
 version = "go1.16beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.16beta1.linux-arm64.tar.gz"
 checksum = "sha256:b0f66bca136b4de8fd29645b50efa9941dc5b9eb5a67a3da837d5f8096b3431c"
 
 [[artifacts]]
 version = "go1.15.15"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.15.linux-amd64.tar.gz"
 checksum = "sha256:0885cf046a9f099e260d98d9ec5d19ea9328f34c8dc4956e1d3cd87daaddb345"
 
 [[artifacts]]
 version = "go1.15.15"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.15.linux-arm64.tar.gz"
 checksum = "sha256:714abb01af210473dd6af331094ad6847162eff81a7fc7241d24f5a85496c9fa"
 
 [[artifacts]]
 version = "go1.15.14"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.14.linux-amd64.tar.gz"
 checksum = "sha256:6f5410c113b803f437d7a1ee6f8f124100e536cc7361920f7e640fedf7add72d"
 
 [[artifacts]]
 version = "go1.15.14"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.14.linux-arm64.tar.gz"
 checksum = "sha256:84e483d1ec7dae591f28f218485f8f67877412e24b8cea626bebf25b6d299c7f"
 
 [[artifacts]]
 version = "go1.15.13"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.13.linux-amd64.tar.gz"
 checksum = "sha256:3d3beec5fc66659018e09f40abb7274b10794229ba7c1e8bdb7d8ca77b656a13"
 
 [[artifacts]]
 version = "go1.15.13"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.13.linux-arm64.tar.gz"
 checksum = "sha256:f3989dca4dea5fbadfec253d7c24e4111773b203e677abb1f01e768a99cc14e6"
 
 [[artifacts]]
 version = "go1.15.12"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.12.linux-amd64.tar.gz"
 checksum = "sha256:bbdb935699e0b24d90e2451346da76121b2412d30930eabcd80907c230d098b7"
 
 [[artifacts]]
 version = "go1.15.12"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.12.linux-arm64.tar.gz"
 checksum = "sha256:a10161e6f0389c45ecd810e114acaba967ea3a4def551fcbb0b1e270996103ed"
 
 [[artifacts]]
 version = "go1.15.11"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.11.linux-amd64.tar.gz"
 checksum = "sha256:8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec"
 
 [[artifacts]]
 version = "go1.15.11"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.11.linux-arm64.tar.gz"
 checksum = "sha256:bfc8f07945296e97c6d28c7999d86b5cab51c7a87eb2b22ca6781c41a6bb6f2d"
 
 [[artifacts]]
 version = "go1.15.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.10.linux-amd64.tar.gz"
 checksum = "sha256:4aa1267517df32f2bf1cc3d55dfc27d0c6b2c2b0989449c96dd19273ccca051d"
 
 [[artifacts]]
 version = "go1.15.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.10.linux-arm64.tar.gz"
 checksum = "sha256:ca3f3e84d863d8e758bfaab65430b12b6cff8f5a5648139245321d3401da64a7"
 
 [[artifacts]]
 version = "go1.15.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.9.linux-amd64.tar.gz"
 checksum = "sha256:a55f3e75bc1098045851d40ea74f9d77efc7958e9af85131a96ca387d38b1834"
 
 [[artifacts]]
 version = "go1.15.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.9.linux-arm64.tar.gz"
 checksum = "sha256:8ea5f3718abde696b4762882b5a9753a8ec148c9b32e3d37e5f2e52a1f9b12ca"
 
 [[artifacts]]
 version = "go1.15.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.8.linux-amd64.tar.gz"
 checksum = "sha256:d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b"
 
 [[artifacts]]
 version = "go1.15.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.8.linux-arm64.tar.gz"
 checksum = "sha256:0e31ea4bf53496b0f0809730520dee98c0ae5c530f3701a19df0ba0a327bf3d2"
 
 [[artifacts]]
 version = "go1.15.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.7.linux-amd64.tar.gz"
 checksum = "sha256:0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3"
 
 [[artifacts]]
 version = "go1.15.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.7.linux-arm64.tar.gz"
 checksum = "sha256:bca4af0c20f86521dfabf3b39fa2f1ceeeb11cebf7e90bdf1de2618c40628539"
 
 [[artifacts]]
 version = "go1.15.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.6.linux-amd64.tar.gz"
 checksum = "sha256:3918e6cc85e7eaaa6f859f1bdbaac772e7a825b0eb423c63d3ae68b21f84b844"
 
 [[artifacts]]
 version = "go1.15.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.6.linux-arm64.tar.gz"
 checksum = "sha256:f87515b9744154ffe31182da9341d0a61eb0795551173d242c8cad209239e492"
 
 [[artifacts]]
 version = "go1.15.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.5.linux-amd64.tar.gz"
 checksum = "sha256:9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d"
 
 [[artifacts]]
 version = "go1.15.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.5.linux-arm64.tar.gz"
 checksum = "sha256:a72a0b036beb4193a0214bca3fca4c5d68a38a4ccf098c909f7ce8bf08567c48"
 
 [[artifacts]]
 version = "go1.15.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.4.linux-amd64.tar.gz"
 checksum = "sha256:eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5"
 
 [[artifacts]]
 version = "go1.15.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.4.linux-arm64.tar.gz"
 checksum = "sha256:6f083b453484fc5f95afb345547a58ccc957cde91348b7a7c68f5b060e488c85"
 
 [[artifacts]]
 version = "go1.15.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.3.linux-amd64.tar.gz"
 checksum = "sha256:010a88df924a81ec21b293b5da8f9b11c176d27c0ee3962dc1738d2352d3c02d"
 
 [[artifacts]]
 version = "go1.15.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.3.linux-arm64.tar.gz"
 checksum = "sha256:b8b88a87ada918ef5189fa5938ef4c46a4f61952a34317612aaac705f4275f80"
 
 [[artifacts]]
 version = "go1.15.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.2.linux-amd64.tar.gz"
 checksum = "sha256:b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552"
 
 [[artifacts]]
 version = "go1.15.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.2.linux-arm64.tar.gz"
 checksum = "sha256:c8ec460cc82d61604b048f9439c06bd591722efce5cd48f49e19b5f6226bd36d"
 
 [[artifacts]]
 version = "go1.15.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.1.linux-amd64.tar.gz"
 checksum = "sha256:70ac0dbf60a8ee9236f337ed0daa7a4c3b98f6186d4497826f68e97c0c0413f6"
 
 [[artifacts]]
 version = "go1.15.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.1.linux-arm64.tar.gz"
 checksum = "sha256:ca21c771d906fbba8840b3a4831b1aa118f6e09b5d028323592faba382787a03"
 
 [[artifacts]]
 version = "go1.15"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15.linux-amd64.tar.gz"
 checksum = "sha256:2d75848ac606061efe52a8068d0e647b35ce487a15bb52272c427df485193602"
 
 [[artifacts]]
 version = "go1.15"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15.linux-arm64.tar.gz"
 checksum = "sha256:7e18d92f61ddf480a4f9a57db09389ae7b9dadf68470d0cb9c00d734a0c57f8d"
 
 [[artifacts]]
 version = "go1.15rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15rc2.linux-amd64.tar.gz"
 checksum = "sha256:f41a08f630f018bc5d9fd100bd9899516e4965356c78165157eb0eda9a17ac09"
 
 [[artifacts]]
 version = "go1.15rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15rc2.linux-arm64.tar.gz"
 checksum = "sha256:e3e2cd95df2491d3cd74af9f73235dbf031dd2ecaf1140ab2793756be87d915f"
 
 [[artifacts]]
 version = "go1.15rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15rc1.linux-amd64.tar.gz"
 checksum = "sha256:ac092ebb92f88366786063e68a9531d5eccac51371f9becb128f064721731b2e"
 
 [[artifacts]]
 version = "go1.15rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15rc1.linux-arm64.tar.gz"
 checksum = "sha256:3baf4336d1bcf1c6707c6e2a402a31cbc87cbd9a63687c97c5149911fe0e5beb"
 
 [[artifacts]]
 version = "go1.15beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.15beta1.linux-amd64.tar.gz"
 checksum = "sha256:11814b7475680a09720f3de32c66bca135289c8d528b2e1132b0ce56b3d9d6d7"
 
 [[artifacts]]
 version = "go1.15beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.15beta1.linux-arm64.tar.gz"
 checksum = "sha256:2648b7d08fe74d0486ec82b3b539d15f3dd63bb34d79e7e57bebc3e5d06b5a38"
 
 [[artifacts]]
 version = "go1.14.15"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.15.linux-amd64.tar.gz"
 checksum = "sha256:c64a57b374a81f7cf1408d2c410a28c6f142414f1ffa9d1062de1d653b0ae0d6"
 
 [[artifacts]]
 version = "go1.14.15"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.15.linux-arm64.tar.gz"
 checksum = "sha256:4d964166a189c22032521c63935437c304bb7f01673b196898cff525897a1c27"
 
 [[artifacts]]
 version = "go1.14.14"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.14.linux-amd64.tar.gz"
 checksum = "sha256:6f1354c9040d65d1622b451f43c324c1e5197aa9242d00c5a117d0e2625f3e0d"
 
 [[artifacts]]
 version = "go1.14.14"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.14.linux-arm64.tar.gz"
 checksum = "sha256:511d764197121f212d130724afb9c296f0cb4a22424e5ae956a5cc043b0f4a29"
 
 [[artifacts]]
 version = "go1.14.13"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.13.linux-amd64.tar.gz"
 checksum = "sha256:bfea0c8d7b70c1ad99b0266b321608db57df75820e8f4333efa448a43da01992"
 
 [[artifacts]]
 version = "go1.14.13"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.13.linux-arm64.tar.gz"
 checksum = "sha256:445b719ebf46d8825360dabad65226db154ca8053de60609bc20f80a17452cbb"
 
 [[artifacts]]
 version = "go1.14.12"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.12.linux-amd64.tar.gz"
 checksum = "sha256:fb26f951c88c0685d7df393611189c58e6eabd3c17bdaef37df11355ab8db9d3"
 
 [[artifacts]]
 version = "go1.14.12"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.12.linux-arm64.tar.gz"
 checksum = "sha256:833c762bf205ae5caaca246d5c2205ae919bad7484f7c38db72941937e28fa24"
 
 [[artifacts]]
 version = "go1.14.11"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.11.linux-amd64.tar.gz"
 checksum = "sha256:ef150041e1af0890ecdd98ebdd6c759096884052a584c09ce50b2b5bb9bab2cd"
 
 [[artifacts]]
 version = "go1.14.11"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.11.linux-arm64.tar.gz"
 checksum = "sha256:6a2dc3c8d41683cf5dbb695d58556ec187fea7ae1afd913e25fc0750ab9c162c"
 
 [[artifacts]]
 version = "go1.14.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.10.linux-amd64.tar.gz"
 checksum = "sha256:66eb6858f375731ba07b0b33f5c813b141a81253e7e74071eec3ae85e9b37098"
 
 [[artifacts]]
 version = "go1.14.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.10.linux-arm64.tar.gz"
 checksum = "sha256:30700f7a9df3148df81013bd38715acd09ca5203b8e0aafa8b985306d5e9882e"
 
 [[artifacts]]
 version = "go1.14.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.9.linux-amd64.tar.gz"
 checksum = "sha256:f0d26ff572c72c9823ae752d3c81819a81a60c753201f51f89637482531c110a"
 
 [[artifacts]]
 version = "go1.14.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.9.linux-arm64.tar.gz"
 checksum = "sha256:65e6cef5c474a3514e754f6a7987c49388bb85a7b370370c1318087ac35427fa"
 
 [[artifacts]]
 version = "go1.14.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.8.linux-amd64.tar.gz"
 checksum = "sha256:5504e077a29d0bd6649ca7b66e317f1a4b264e960f74115d6f0f405c49a8e738"
 
 [[artifacts]]
 version = "go1.14.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.8.linux-arm64.tar.gz"
 checksum = "sha256:52219e5508cbd8c93070d85f5ac8f1049eac5e89399666c46aa9edd9b1112725"
 
 [[artifacts]]
 version = "go1.14.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.7.linux-amd64.tar.gz"
 checksum = "sha256:4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5"
 
 [[artifacts]]
 version = "go1.14.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.7.linux-arm64.tar.gz"
 checksum = "sha256:fe5b6f6e441f3cb7b53ebf1a010bbebcb720ac98124984cfe2e51d72b8a58c71"
 
 [[artifacts]]
 version = "go1.14.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.6.linux-amd64.tar.gz"
 checksum = "sha256:5c566ddc2e0bcfc25c26a5dc44a440fcc0177f7350c1f01952b34d5989a0d287"
 
 [[artifacts]]
 version = "go1.14.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.6.linux-arm64.tar.gz"
 checksum = "sha256:291bccfd7d7f1915599bbcc90e49d9fccfcb0004b7c62a2f5cdf0f96a09d6a3e"
 
 [[artifacts]]
 version = "go1.14.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.5.linux-amd64.tar.gz"
 checksum = "sha256:82a1b84f16858db03231eb201f90cce2a991078dda543879b87e738e2586854b"
 
 [[artifacts]]
 version = "go1.14.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.5.linux-arm64.tar.gz"
 checksum = "sha256:27a3b3ca4fd60c8680cd2235d5ca38cad41ee8c41bd61891d39a8501ada5f677"
 
 [[artifacts]]
 version = "go1.14.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.4.linux-amd64.tar.gz"
 checksum = "sha256:aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c067"
 
 [[artifacts]]
 version = "go1.14.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.4.linux-arm64.tar.gz"
 checksum = "sha256:05dc46ada4e23a1f58e72349f7c366aae2e9c7a7f1e7653095538bc5bba5e077"
 
 [[artifacts]]
 version = "go1.14.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.3.linux-amd64.tar.gz"
 checksum = "sha256:1c39eac4ae95781b066c144c58e45d6859652247f7515f0d2cba7be7d57d2226"
 
 [[artifacts]]
 version = "go1.14.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.3.linux-arm64.tar.gz"
 checksum = "sha256:a7a593e2ee079d83a1943edcd1c9ed2dae7529666fce04de8c142fb61c7cdd3e"
 
 [[artifacts]]
 version = "go1.14.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.2.linux-amd64.tar.gz"
 checksum = "sha256:6272d6e940ecb71ea5636ddb5fab3933e087c1356173c61f4a803895e947ebb3"
 
 [[artifacts]]
 version = "go1.14.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.2.linux-arm64.tar.gz"
 checksum = "sha256:bb6d22fe5806352c3d0826676654e09b6e41eb1af52e8d506d3fa85adf7f8d88"
 
 [[artifacts]]
 version = "go1.14.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.1.linux-amd64.tar.gz"
 checksum = "sha256:2f49eb17ce8b48c680cdb166ffd7389702c0dec6effa090c324804a5cac8a7f8"
 
 [[artifacts]]
 version = "go1.14.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.1.linux-arm64.tar.gz"
 checksum = "sha256:5d8f2c202f35481617e24e63cca30c6afb1ec2585006c4a6ecf16c5f4928ab3c"
 
 [[artifacts]]
 version = "go1.14"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14.linux-amd64.tar.gz"
 checksum = "sha256:08df79b46b0adf498ea9f320a0f23d6ec59e9003660b4c9c1ce8e5e2c6f823ca"
 
 [[artifacts]]
 version = "go1.14"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14.linux-arm64.tar.gz"
 checksum = "sha256:cd813387f770c07819912f8ff4b9796a4e317dee92548b7226a19e60ac79eb27"
 
 [[artifacts]]
 version = "go1.14rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14rc1.linux-amd64.tar.gz"
 checksum = "sha256:69398d41e5f6b87cdf3969aae665be4dfd3cc2ef36a61ab47a261f96130ed788"
 
 [[artifacts]]
 version = "go1.14rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14rc1.linux-arm64.tar.gz"
 checksum = "sha256:a5509448b06f02f5198fe8bbf5af88ab483af9c46f231c3f308748016fbc32c9"
 
 [[artifacts]]
 version = "go1.14beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.14beta1.linux-amd64.tar.gz"
 checksum = "sha256:ebe68aa4219b673dbd060b8a6d9a339b6b6b0383772aa4349c8183f0a8f339e4"
 
 [[artifacts]]
 version = "go1.14beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.14beta1.linux-arm64.tar.gz"
 checksum = "sha256:91a92cfb7644c59c4b51d50fb7225b898675effaa65659a71c06aa6a42c0ada5"
 
 [[artifacts]]
 version = "go1.13.15"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.15.linux-amd64.tar.gz"
 checksum = "sha256:01cc3ddf6273900eba3e2bf311238828b7168b822bb57a9ccab4d7aa2acd6028"
 
 [[artifacts]]
 version = "go1.13.15"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.15.linux-arm64.tar.gz"
 checksum = "sha256:a5c59e3f0aeaf6e939790152a8bfabb91d70c9787afb7aee06aef9bd4411c551"
 
 [[artifacts]]
 version = "go1.13.14"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.14.linux-amd64.tar.gz"
 checksum = "sha256:32617db984b18308f2b00279c763bff060d2739229cb8037217a49c9e691b46a"
 
 [[artifacts]]
 version = "go1.13.14"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.14.linux-arm64.tar.gz"
 checksum = "sha256:ee5f84e3bc0548e4963344a887f684458bec1e5a822d0d413d1c6925b784a16e"
 
 [[artifacts]]
 version = "go1.13.13"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.13.linux-amd64.tar.gz"
 checksum = "sha256:0b8573c2335bebef53e819ab8d323456dc2b94838bebdbd8cc6623bb8a6d77b7"
 
 [[artifacts]]
 version = "go1.13.13"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.13.linux-arm64.tar.gz"
 checksum = "sha256:999fcd9090b164062e166523086a54f4152549c41f627ff5ccad3c3ec2da0657"
 
 [[artifacts]]
 version = "go1.13.12"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.12.linux-amd64.tar.gz"
 checksum = "sha256:9cacc6653563771b458c13056265aa0c21b8a23ca9408278484e4efde4160618"
 
 [[artifacts]]
 version = "go1.13.12"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.12.linux-arm64.tar.gz"
 checksum = "sha256:7a8b4e7841d978c95dae8ef53e19811ee2d5c595a1c5ec7afed74bb8f71588b8"
 
 [[artifacts]]
 version = "go1.13.11"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.11.linux-amd64.tar.gz"
 checksum = "sha256:a4d71ca9e02923fa96669a4b5faf78ee8331b18e7209b09dd87fe763b4838ada"
 
 [[artifacts]]
 version = "go1.13.11"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.11.linux-arm64.tar.gz"
 checksum = "sha256:6c81c0ce79be2bd3ac5ea69c709ea9bd588069632ded4ac39d58dadf4d2f93e6"
 
 [[artifacts]]
 version = "go1.13.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.10.linux-amd64.tar.gz"
 checksum = "sha256:8a4cbc9f2b95d114c38f6cbe94a45372d48c604b707db2057c787398dfbf8e7f"
 
 [[artifacts]]
 version = "go1.13.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.10.linux-arm64.tar.gz"
 checksum = "sha256:f16f19947855b410e48f395ca488bd39223c7b35e8b69c7f15ec00201e20b572"
 
 [[artifacts]]
 version = "go1.13.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.9.linux-amd64.tar.gz"
 checksum = "sha256:f4ad8180dd0aaf7d7cda7e2b0a2bf27e84131320896d376549a7d849ecf237d7"
 
 [[artifacts]]
 version = "go1.13.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.9.linux-arm64.tar.gz"
 checksum = "sha256:b53cb466d7986e5e17a3d4c196bc95df08a35968eced5efd7e128387a246c46e"
 
 [[artifacts]]
 version = "go1.13.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.8.linux-amd64.tar.gz"
 checksum = "sha256:0567734d558aef19112f2b2873caa0c600f1b4a5827930eb5a7f35235219e9d8"
 
 [[artifacts]]
 version = "go1.13.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.8.linux-arm64.tar.gz"
 checksum = "sha256:b46c0235054d0eb69a295a2634aec8a11c7ae19b3dc53556a626b89dc1f8cdb0"
 
 [[artifacts]]
 version = "go1.13.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.7.linux-amd64.tar.gz"
 checksum = "sha256:b3dd4bd781a0271b33168e627f7f43886b4c5d1c794a4015abf34e99c6526ca3"
 
 [[artifacts]]
 version = "go1.13.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.7.linux-arm64.tar.gz"
 checksum = "sha256:8717de6c662ada01b7bf318f5025c046b57f8c10cd39a88268bdc171cc7e4eab"
 
 [[artifacts]]
 version = "go1.13.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.6.linux-amd64.tar.gz"
 checksum = "sha256:a1bc06deb070155c4f67c579f896a45eeda5a8fa54f35ba233304074c4abbbbd"
 
 [[artifacts]]
 version = "go1.13.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.6.linux-arm64.tar.gz"
 checksum = "sha256:0a18125c4ed80f9c3045cf92384670907c4796b43ed63c4307210fe93e5bbca5"
 
 [[artifacts]]
 version = "go1.13.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.5.linux-amd64.tar.gz"
 checksum = "sha256:512103d7ad296467814a6e3f635631bd35574cab3369a97a323c9a585ccaa569"
 
 [[artifacts]]
 version = "go1.13.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.5.linux-arm64.tar.gz"
 checksum = "sha256:227b718923e20c846460bbecddde9cb86bad73acc5fb6f8e1a96b81b5c84668b"
 
 [[artifacts]]
 version = "go1.13.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.4.linux-amd64.tar.gz"
 checksum = "sha256:692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c"
 
 [[artifacts]]
 version = "go1.13.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.4.linux-arm64.tar.gz"
 checksum = "sha256:8b8d99eb07206f082468fb4d0ec962a819ae45d54065fc1ed6e2c502e774aaf0"
 
 [[artifacts]]
 version = "go1.13.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.3.linux-amd64.tar.gz"
 checksum = "sha256:0804bf02020dceaa8a7d7275ee79f7a142f1996bfd0c39216ccb405f93f994c0"
 
 [[artifacts]]
 version = "go1.13.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.3.linux-arm64.tar.gz"
 checksum = "sha256:9fa65ae42665baff53802091b49b83af6f2e397986b6cbea2ae30e2c7ee0f2f2"
 
 [[artifacts]]
 version = "go1.13.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.2.linux-amd64.tar.gz"
 checksum = "sha256:293b41a6ccd735eebcfb4094b6931bfd187595555cecf3e4386e9e119220c0b7"
 
 [[artifacts]]
 version = "go1.13.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.2.linux-arm64.tar.gz"
 checksum = "sha256:a2d27f341d6b7968f9da229990aa9ab7a6d4bd1c722945be11576a09eb538482"
 
 [[artifacts]]
 version = "go1.13.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.1.linux-amd64.tar.gz"
 checksum = "sha256:94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124"
 
 [[artifacts]]
 version = "go1.13.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.1.linux-arm64.tar.gz"
 checksum = "sha256:8af8787b7c2a3c0eb3f20f872577fcb6c36098bf725c59c4923921443084c807"
 
 [[artifacts]]
 version = "go1.13"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13.linux-amd64.tar.gz"
 checksum = "sha256:68a2297eb099d1a76097905a2ce334e3155004ec08cdea85f24527be3c48e856"
 
 [[artifacts]]
 version = "go1.13"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13.linux-arm64.tar.gz"
 checksum = "sha256:e2a61328101eff3b9c1ba47ecfec5eb2fdc3eb35d8c27d505737ba98bfcb197b"
 
 [[artifacts]]
 version = "go1.13rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13rc2.linux-amd64.tar.gz"
 checksum = "sha256:3cd4490021a5f1f25a7440edca03910e40a38e587b578cf52ab7143a81db1861"
 
 [[artifacts]]
 version = "go1.13rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13rc2.linux-arm64.tar.gz"
 checksum = "sha256:184c9fff6bba9da1cf23ba7f52561cc777ac7feaf73621b3824f4a30ffa4648d"
 
 [[artifacts]]
 version = "go1.13rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13rc1.linux-amd64.tar.gz"
 checksum = "sha256:0b45d086aefcfb9d0ebe7fc9ffbe470e45f9c104a6a97ea275512152cdbfead1"
 
 [[artifacts]]
 version = "go1.13rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13rc1.linux-arm64.tar.gz"
 checksum = "sha256:be16145c9fa218340766b19edd175b109adab826155add2fd504430a751aaa19"
 
 [[artifacts]]
 version = "go1.13beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.13beta1.linux-amd64.tar.gz"
 checksum = "sha256:dbd131c92f381a5bc5ca1f0cfd942cb8be7d537007b6f412b5be41ff38a7d0d9"
 
 [[artifacts]]
 version = "go1.13beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.13beta1.linux-arm64.tar.gz"
 checksum = "sha256:298a325d8eeba561a26312a9cdc821a96873c10fca7f48a7f98bbd8848bd8bd4"
 
 [[artifacts]]
 version = "go1.12.17"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.17.linux-amd64.tar.gz"
 checksum = "sha256:a53dd476129d496047487bfd53d021dd17e0c96895865a0e7d0469ce3db8c8d2"
 
 [[artifacts]]
 version = "go1.12.17"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.17.linux-arm64.tar.gz"
 checksum = "sha256:9d0819cce1451abdb090071880fe8771f16a3bcee71d6f6906023d17799574e2"
 
 [[artifacts]]
 version = "go1.12.16"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.16.linux-amd64.tar.gz"
 checksum = "sha256:bf3a85d75658144c06ce986ba05e07ef08af4320089b74b1d41de3b0f340ea7e"
 
 [[artifacts]]
 version = "go1.12.16"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.16.linux-arm64.tar.gz"
 checksum = "sha256:a01df310bfeffc67480982cf6ad50c9b83f9aaf4ac855d5e581b95eb727bb24c"
 
 [[artifacts]]
 version = "go1.12.15"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.15.linux-amd64.tar.gz"
 checksum = "sha256:61068419f3d3fcd3cc415c352c4a93d6ae0e723ac18a22ac572b4904d78b5a4c"
 
 [[artifacts]]
 version = "go1.12.15"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.15.linux-arm64.tar.gz"
 checksum = "sha256:cff1a28f0b207dd54230bf822cdcfbcc7cd411261a9366616a05a1fa1fbeedd3"
 
 [[artifacts]]
 version = "go1.12.14"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.14.linux-amd64.tar.gz"
 checksum = "sha256:925a1a9d8b31c2425d7313fe73d3342288968a66e26cd8bf1b6b5656f4603fcb"
 
 [[artifacts]]
 version = "go1.12.14"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.14.linux-arm64.tar.gz"
 checksum = "sha256:1ab765f4cf74f05cfba40ddcea9160ca6cf9a57915036a559ca1691942862e7c"
 
 [[artifacts]]
 version = "go1.12.13"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.13.linux-amd64.tar.gz"
 checksum = "sha256:da036454cb3353f9f507f0ceed4048feac611065e4e1818b434365eb32ac9bdc"
 
 [[artifacts]]
 version = "go1.12.13"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.13.linux-arm64.tar.gz"
 checksum = "sha256:dcfcb3785292c98f7a75c2276169dfe2d445c19f8ffe1d40b3f7b8f59712d361"
 
 [[artifacts]]
 version = "go1.12.12"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.12.linux-amd64.tar.gz"
 checksum = "sha256:4cf11ac6a8fa42d26ab85e27a5d916ee171900a87745d9f7d4a29a21587d78fc"
 
 [[artifacts]]
 version = "go1.12.12"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.12.linux-arm64.tar.gz"
 checksum = "sha256:a7e2fed536904f2bf7007deed3609b3484c55660821bd2faaeb6928fa62fd33e"
 
 [[artifacts]]
 version = "go1.12.11"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.11.linux-amd64.tar.gz"
 checksum = "sha256:2c5960292da8b747d83f171a28a04116b2977e809169c344268c893e4cf0a857"
 
 [[artifacts]]
 version = "go1.12.11"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.11.linux-arm64.tar.gz"
 checksum = "sha256:a05361badb95f6cc5724e32f59b0f33048dfca63b539cf2bd8ab77fa4f2ba923"
 
 [[artifacts]]
 version = "go1.12.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.10.linux-amd64.tar.gz"
 checksum = "sha256:aaa84147433aed24e70b31da369bb6ca2859464a45de47c2a5023d8573412f6b"
 
 [[artifacts]]
 version = "go1.12.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.10.linux-arm64.tar.gz"
 checksum = "sha256:d45d1eebe10a33a3d850cafcefd45200091a9ddb880857135307ee0de9424d24"
 
 [[artifacts]]
 version = "go1.12.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.9.linux-amd64.tar.gz"
 checksum = "sha256:ac2a6efcc1f5ec8bdc0db0a988bb1d301d64b6d61b7e8d9e42f662fbb75a2b9b"
 
 [[artifacts]]
 version = "go1.12.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.9.linux-arm64.tar.gz"
 checksum = "sha256:3606dc6ce8b4a5faad81d7365714a86b3162df041a32f44568418c9efbd7f646"
 
 [[artifacts]]
 version = "go1.12.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.8.linux-amd64.tar.gz"
 checksum = "sha256:bd26cd4962a362ed3c11835bca32c2e131c2ae050304f2c4df9fa6ded8db85d2"
 
 [[artifacts]]
 version = "go1.12.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.8.linux-arm64.tar.gz"
 checksum = "sha256:15e9e0b5b414d1a0322896368c0050af6ab1cd82d050e93f8eceb38ef2626652"
 
 [[artifacts]]
 version = "go1.12.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.7.linux-amd64.tar.gz"
 checksum = "sha256:66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9"
 
 [[artifacts]]
 version = "go1.12.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.7.linux-arm64.tar.gz"
 checksum = "sha256:4da1f7198a8fa0c4067852656b6c10153a4eca5a26aca28ef02ae9f4a7939ba5"
 
 [[artifacts]]
 version = "go1.12.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.6.linux-amd64.tar.gz"
 checksum = "sha256:dbcf71a3c1ea53b8d54ef1b48c85a39a6c9a935d01fc8291ff2b92028e59913c"
 
 [[artifacts]]
 version = "go1.12.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.6.linux-arm64.tar.gz"
 checksum = "sha256:8f4e3909c74b4f3f3956715f32419b28d32a4ad57dbd79f74b7a8a920b21a1a3"
 
 [[artifacts]]
 version = "go1.12.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.5.linux-amd64.tar.gz"
 checksum = "sha256:aea86e3c73495f205929cfebba0d63f1382c8ac59be081b6351681415f4063cf"
 
 [[artifacts]]
 version = "go1.12.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.5.linux-arm64.tar.gz"
 checksum = "sha256:ff09f34935cd189a4912f3f308ec83e4683c309304144eae9cf60ebc552e7cd8"
 
 [[artifacts]]
 version = "go1.12.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.4.linux-amd64.tar.gz"
 checksum = "sha256:d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5"
 
 [[artifacts]]
 version = "go1.12.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.4.linux-arm64.tar.gz"
 checksum = "sha256:b7d7b4319b2d86a2ed20cef3b47aa23f0c97612b469178deecd021610f6917df"
 
 [[artifacts]]
 version = "go1.12.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.3.linux-amd64.tar.gz"
 checksum = "sha256:3924819eed16e55114f02d25d03e77c916ec40b7fd15c8acb5838b63135b03df"
 
 [[artifacts]]
 version = "go1.12.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.3.linux-arm64.tar.gz"
 checksum = "sha256:4deb7f3b90d03f71f5cac3654e0e1f9cb46c45b85c5475510222b958e4ea2ed6"
 
 [[artifacts]]
 version = "go1.12.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.2.linux-amd64.tar.gz"
 checksum = "sha256:f28c1fde8f293cc5c83ae8de76373cf76ae9306909564f54e0edcf140ce8fe3f"
 
 [[artifacts]]
 version = "go1.12.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.2.linux-arm64.tar.gz"
 checksum = "sha256:598558fe54bbdce8b676f81e37f514dd70b8fc1377086658ae6e836480e900eb"
 
 [[artifacts]]
 version = "go1.12.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.1.linux-amd64.tar.gz"
 checksum = "sha256:2a3fdabf665496a0db5f41ec6af7a9b15a49fbe71a85a50ca38b1f13a103aeec"
 
 [[artifacts]]
 version = "go1.12.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.1.linux-arm64.tar.gz"
 checksum = "sha256:10dba44cf95c7aa7abc3c72610c12ebcaf7cad6eed761d5ad92736ca3bc0d547"
 
 [[artifacts]]
 version = "go1.12"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12.linux-amd64.tar.gz"
 checksum = "sha256:750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13"
 
 [[artifacts]]
 version = "go1.12"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12.linux-arm64.tar.gz"
 checksum = "sha256:b7bf59c2f1ac48eb587817a2a30b02168ecc99635fc19b6e677cce01406e3fac"
 
 [[artifacts]]
 version = "go1.12rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12rc1.linux-amd64.tar.gz"
 checksum = "sha256:e5a03e1f2e065b17b2fbbd3429f18a6f51fe2848e0120586652b9f14ada72c9a"
 
 [[artifacts]]
 version = "go1.12rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12rc1.linux-arm64.tar.gz"
 checksum = "sha256:654b90f75902d501e2201a7b438965132fd1242a102f54529e9ff7dbbdf0d4bb"
 
 [[artifacts]]
 version = "go1.12beta2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12beta2.linux-amd64.tar.gz"
 checksum = "sha256:9e4884b46a72e0558187a8af6e8733e039432df1b755f14b361f18b63fa5a63e"
 
 [[artifacts]]
 version = "go1.12beta2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12beta2.linux-arm64.tar.gz"
 checksum = "sha256:77d80484e455ad65aa0778aa82391c02ded01a37ee65f7887167dc03a6ef3251"
 
 [[artifacts]]
 version = "go1.12beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.12beta1.linux-amd64.tar.gz"
 checksum = "sha256:65bfd4a99925f1f85d712f4c1109977aa24ee4c6e198162bf8e819fdde19e875"
 
 [[artifacts]]
 version = "go1.12beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.12beta1.linux-arm64.tar.gz"
 checksum = "sha256:df79a288b2c569bd26e43ea3acc245b7eabae897b4783f7b4acffdd97ba0a01c"
 
 [[artifacts]]
 version = "go1.11.13"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.13.linux-amd64.tar.gz"
 checksum = "sha256:50fe8e13592f8cf22304b9c4adfc11849a2c3d281b1d7e09c924ae24874c6daa"
 
 [[artifacts]]
 version = "go1.11.13"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.13.linux-arm64.tar.gz"
 checksum = "sha256:e94329c97b38b5bffe9c18e84e9f521dc995e02df7696897a7626293da9ac593"
 
 [[artifacts]]
 version = "go1.11.12"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.12.linux-amd64.tar.gz"
 checksum = "sha256:14ec881815eb9e6618f95df5eb385d961283efc196d97912595ba6484a56180d"
 
 [[artifacts]]
 version = "go1.11.12"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.12.linux-arm64.tar.gz"
 checksum = "sha256:d79c075773fc3121d0e719b83b46115efff685ade94545a52f3ac22f43d76196"
 
 [[artifacts]]
 version = "go1.11.11"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.11.linux-amd64.tar.gz"
 checksum = "sha256:2fd47b824d6e32154b0f6c8742d066d816667715763e06cebb710304b195c775"
 
 [[artifacts]]
 version = "go1.11.11"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.11.linux-arm64.tar.gz"
 checksum = "sha256:5ee39ea08e5d8c017658f36d0f969b17a44d49576214f4a00710f2d98bb773be"
 
 [[artifacts]]
 version = "go1.11.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.10.linux-amd64.tar.gz"
 checksum = "sha256:aefaa228b68641e266d1f23f1d95dba33f17552ba132878b65bb798ffa37e6d0"
 
 [[artifacts]]
 version = "go1.11.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.10.linux-arm64.tar.gz"
 checksum = "sha256:6743c54f0e33873c113cbd66df7749e81785f378567734831c2e5d3b6b6aa2b8"
 
 [[artifacts]]
 version = "go1.11.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.9.linux-amd64.tar.gz"
 checksum = "sha256:e88aa3e39104e3ba6a95a4e05629348b4a1ec82791fb3c941a493ca349730608"
 
 [[artifacts]]
 version = "go1.11.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.9.linux-arm64.tar.gz"
 checksum = "sha256:892ab6c2510c4caa5905b3b1b6a1d4c6f04e384841fec50881ca2be7e8accf05"
 
 [[artifacts]]
 version = "go1.11.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.8.linux-amd64.tar.gz"
 checksum = "sha256:e32ab1c934b747999d04e8a550b97f4647f8b1b43e152de5650d4476bfd1d2e1"
 
 [[artifacts]]
 version = "go1.11.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.8.linux-arm64.tar.gz"
 checksum = "sha256:68c42239d118b27f5e52a449f444c8a53e64a181b12d9ecbda14d0c3b765a5ee"
 
 [[artifacts]]
 version = "go1.11.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.7.linux-amd64.tar.gz"
 checksum = "sha256:db687814288b3b541c1754dfd4ecc2b8fd0d5e7995624945e3054a350ca573d8"
 
 [[artifacts]]
 version = "go1.11.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.7.linux-arm64.tar.gz"
 checksum = "sha256:fe7ba5046aa4f52ae8fa36531aac4a949ad8e10c02b0f4aa05a420b4e803f8c6"
 
 [[artifacts]]
 version = "go1.11.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.6.linux-amd64.tar.gz"
 checksum = "sha256:4e1864282d8d20010d6385a12a1e35641783a380a7c57907bfb46a5499c5eb49"
 
 [[artifacts]]
 version = "go1.11.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.6.linux-arm64.tar.gz"
 checksum = "sha256:29f64505cea47c57a46e2c8001ecf8d0c01cbf1ec86de96f4e3126b94a12ebb7"
 
 [[artifacts]]
 version = "go1.11.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.5.linux-amd64.tar.gz"
 checksum = "sha256:ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25"
 
 [[artifacts]]
 version = "go1.11.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.5.linux-arm64.tar.gz"
 checksum = "sha256:6ee9a5714444182a236d3cc4636e74cfc5e24a1bacf0463ac71dcf0e7d4288ed"
 
 [[artifacts]]
 version = "go1.11.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.4.linux-amd64.tar.gz"
 checksum = "sha256:fb26c30e6a04ad937bbc657a1b5bba92f80096af1e8ee6da6430c045a8db3a5b"
 
 [[artifacts]]
 version = "go1.11.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.4.linux-arm64.tar.gz"
 checksum = "sha256:b76df430ba8caff197b8558921deef782cdb20b62fa36fa93f81a8c08ab7c8e7"
 
 [[artifacts]]
 version = "go1.11.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.3.linux-amd64.tar.gz"
 checksum = "sha256:d20a4869ffb13cee0f7ee777bf18c7b9b67ef0375f93fac1298519e0c227a07f"
 
 [[artifacts]]
 version = "go1.11.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.3.linux-arm64.tar.gz"
 checksum = "sha256:723c54cb081dd629a44d620197e4a789dccdfe6dee7f8b4ad7a6659f76952056"
 
 [[artifacts]]
 version = "go1.11.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.2.linux-amd64.tar.gz"
 checksum = "sha256:1dfe664fa3d8ad714bbd15a36627992effd150ddabd7523931f077b3926d736d"
 
 [[artifacts]]
 version = "go1.11.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.2.linux-arm64.tar.gz"
 checksum = "sha256:98a42b9b8d3bacbcc6351a1e39af52eff582d0bc3ac804cd5a97ce497dd84026"
 
 [[artifacts]]
 version = "go1.11.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.1.linux-amd64.tar.gz"
 checksum = "sha256:2871270d8ff0c8c69f161aaae42f9f28739855ff5c5204752a8d92a1c9f63993"
 
 [[artifacts]]
 version = "go1.11.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.1.linux-arm64.tar.gz"
 checksum = "sha256:25e1a281b937022c70571ac5a538c9402dd74bceb71c2526377a7e5747df5522"
 
 [[artifacts]]
 version = "go1.11"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11.linux-amd64.tar.gz"
 checksum = "sha256:b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499"
 
 [[artifacts]]
 version = "go1.11"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11.linux-arm64.tar.gz"
 checksum = "sha256:e4853168f41d0bea65e4d38f992a2d44b58552605f623640c5ead89d515c56c9"
 
 [[artifacts]]
 version = "go1.11rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11rc2.linux-amd64.tar.gz"
 checksum = "sha256:7d3fc1dec64b056cbd22ffd80bb9733725c1296aabfd58cc92bab8a5c6560e03"
 
 [[artifacts]]
 version = "go1.11rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11rc2.linux-arm64.tar.gz"
 checksum = "sha256:5b160c1ea4c863f82d5d9ebad51edc08f5a5ecf368d315c8aff2c99420fb075c"
 
 [[artifacts]]
 version = "go1.11rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11rc1.linux-amd64.tar.gz"
 checksum = "sha256:1a071f069982427b245aea736d3174e065a12e8481c34051c672d62a5ca59ca9"
 
 [[artifacts]]
 version = "go1.11rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11rc1.linux-arm64.tar.gz"
 checksum = "sha256:8a3d96e3e7604cf5390b7e318ff35112cdb13e0e44ddf0130659cefd196ab50e"
 
 [[artifacts]]
 version = "go1.11beta3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11beta3.linux-amd64.tar.gz"
 checksum = "sha256:674c1091f4712c1cfdcd77ecddafe6aef81cbda740af64a6e3f893ddf3dfb11c"
 
 [[artifacts]]
 version = "go1.11beta3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11beta3.linux-arm64.tar.gz"
 checksum = "sha256:d8fb9d36a3c862a68db828eb22268e0723e3e245f41cc33f5da0a5b7e293fea5"
 
 [[artifacts]]
 version = "go1.11beta2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11beta2.linux-amd64.tar.gz"
 checksum = "sha256:ccb60f1ae6efe4fcef115db8143eb7f9ba134c63486f47b2c5176706ede35af5"
 
 [[artifacts]]
 version = "go1.11beta2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11beta2.linux-arm64.tar.gz"
 checksum = "sha256:835fc6ebae5cb4368fc39683a911fe5a25c36b4251b2b254112f3fc8f36a9f39"
 
 [[artifacts]]
 version = "go1.11beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.11beta1.linux-amd64.tar.gz"
 checksum = "sha256:df7fe096ffab5d331d35c6d038d2ec0426b45ce17f55a93037e371d3af9d4e6d"
 
 [[artifacts]]
 version = "go1.11beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.11beta1.linux-arm64.tar.gz"
 checksum = "sha256:9c1795148e777c81ac3cb381e3ea970eea60f5db2323658c061e5c4382125dd4"
 
 [[artifacts]]
 version = "go1.10.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10.8.linux-amd64.tar.gz"
 checksum = "sha256:d8626fb6f9a3ab397d88c483b576be41fa81eefcec2fd18562c87626dbb3c39e"
 
 [[artifacts]]
 version = "go1.10.8"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10.8.linux-arm64.tar.gz"
 checksum = "sha256:0921a76e78022ec2ae217e85b04940e2e9912b4c3218d96a827deedb9abe1c7b"
 
 [[artifacts]]
 version = "go1.10.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10.7.linux-amd64.tar.gz"
 checksum = "sha256:1aabe10919048822f3bb1865f7a22f8b78387a12c03cd573101594bc8fb33579"
 
 [[artifacts]]
 version = "go1.10.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10.7.linux-arm64.tar.gz"
 checksum = "sha256:cb5a274f7c8f6186957e4503e724dda8aeffe84b76a146748c55ea5bb22d9ae4"
 
 [[artifacts]]
 version = "go1.10.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10.6.linux-amd64.tar.gz"
 checksum = "sha256:acbdedf28b55b38d2db6f06209a25a869a36d31bdcf09fd2ec3d40e1279e0592"
 
 [[artifacts]]
 version = "go1.10.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10.6.linux-arm64.tar.gz"
 checksum = "sha256:0fcbfbcbf6373c0b6876786900a4a100c1ed9af86bd3258f23ab498cca4c02a1"
 
 [[artifacts]]
 version = "go1.10.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10.5.linux-amd64.tar.gz"
 checksum = "sha256:a035d9beda8341b645d3f45a1b620cf2d8fb0c5eb409be36b389c0fd384ecc3a"
 
 [[artifacts]]
 version = "go1.10.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10.5.linux-arm64.tar.gz"
 checksum = "sha256:b4c16fcee18bc79de2fa4776c8d0f9bc164ddfc32101e96fe1da83ebe881e3df"
 
 [[artifacts]]
 version = "go1.10.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10.4.linux-amd64.tar.gz"
 checksum = "sha256:fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec"
 
 [[artifacts]]
 version = "go1.10.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10.4.linux-arm64.tar.gz"
 checksum = "sha256:2e0f9e99aeefaabba280b2bf85db0336da122accde73603159b3d72d0b2bd512"
 
 [[artifacts]]
 version = "go1.10.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10.3.linux-amd64.tar.gz"
 checksum = "sha256:fa1b0e45d3b647c252f51f5e1204aba049cde4af177ef9f2181f43004f901035"
 
 [[artifacts]]
 version = "go1.10.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10.3.linux-arm64.tar.gz"
 checksum = "sha256:355128a05b456c9e68792143801ad18e0431510a53857f640f7b30ba92624ed2"
 
 [[artifacts]]
 version = "go1.10.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10.2.linux-amd64.tar.gz"
 checksum = "sha256:4b677d698c65370afa33757b6954ade60347aaca310ea92a63ed717d7cb0c2ff"
 
 [[artifacts]]
 version = "go1.10.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10.2.linux-arm64.tar.gz"
 checksum = "sha256:d6af66c71b12d63c754d5bf49c3007dc1c9821eb1a945118bfd5a539a327c4c8"
 
 [[artifacts]]
 version = "go1.10.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10.1.linux-amd64.tar.gz"
 checksum = "sha256:72d820dec546752e5a8303b33b009079c15c2390ce76d67cf514991646c6127b"
 
 [[artifacts]]
 version = "go1.10.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10.1.linux-arm64.tar.gz"
 checksum = "sha256:1e07a159414b5090d31166d1a06ee501762076ef21140dcd54cdcbe4e68a9c9b"
 
 [[artifacts]]
 version = "go1.10"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10.linux-amd64.tar.gz"
 checksum = "sha256:b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33"
 
 [[artifacts]]
 version = "go1.10"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10.linux-arm64.tar.gz"
 checksum = "sha256:efb47e5c0e020b180291379ab625c6ec1c2e9e9b289336bc7169e6aa1da43fd8"
 
 [[artifacts]]
 version = "go1.10rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10rc2.linux-amd64.tar.gz"
 checksum = "sha256:6a6a4c0654bc603bcfee4d6ac34a479c260ac61b3edcc8d6773384eb0bda512e"
 
 [[artifacts]]
 version = "go1.10rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10rc2.linux-arm64.tar.gz"
 checksum = "sha256:dfa7fbe299b3766b94fb4bc231db4330b9860c44a57274f6a0d418bf00eccbc8"
 
 [[artifacts]]
 version = "go1.10rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10rc1.linux-amd64.tar.gz"
 checksum = "sha256:c10d3cc7760bf3799037bd39027bbffdc568aea21d6fe60fe833373289c7b7c6"
 
 [[artifacts]]
 version = "go1.10rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10rc1.linux-arm64.tar.gz"
 checksum = "sha256:3a749faf38e80025b832dae250442ddc86d5bc353d752c781ea632e904922ff1"
 
 [[artifacts]]
 version = "go1.10beta2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10beta2.linux-amd64.tar.gz"
 checksum = "sha256:ab3abb7d731dd5ac7a06d5d5e64ef19946f57d4ce34555d262a87b8899901a93"
 
 [[artifacts]]
 version = "go1.10beta2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10beta2.linux-arm64.tar.gz"
 checksum = "sha256:2f51e94a227473d41bf3d9dbbdc5855308e64d82fb740a15019bd4fe733c9518"
 
 [[artifacts]]
 version = "go1.10beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.10beta1.linux-amd64.tar.gz"
 checksum = "sha256:ec7a10b5bf147a8e06cf64e27384ff3c6d065c74ebd8fdd31f572714f74a1055"
 
 [[artifacts]]
 version = "go1.10beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.10beta1.linux-arm64.tar.gz"
 checksum = "sha256:3a80555b3c4beecfb9af88c718f8676101ada74dea84f4aa1ade29d2d78554e0"
 
 [[artifacts]]
 version = "go1.9.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9.7.linux-amd64.tar.gz"
 checksum = "sha256:88573008f4f6233b81f81d8ccf92234b4f67238df0f0ab173d75a302a1f3d6ee"
 
 [[artifacts]]
 version = "go1.9.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9.7.linux-arm64.tar.gz"
 checksum = "sha256:68f48c29f93e4c69bbbdb335f473d666b9f8791643f4003ef45283a968b41f86"
 
 [[artifacts]]
 version = "go1.9.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9.6.linux-amd64.tar.gz"
 checksum = "sha256:d1eb07f99ac06906225ac2b296503f06cc257b472e7d7817b8f822fe3766ebfe"
 
 [[artifacts]]
 version = "go1.9.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9.6.linux-arm64.tar.gz"
 checksum = "sha256:8596d64b9f582d6209c04513824e428d1c356276180d2089d4dfcf4c7cf8a6cc"
 
 [[artifacts]]
 version = "go1.9.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9.5.linux-amd64.tar.gz"
 checksum = "sha256:d21bdabf4272c2248c41b45cec606844bdc5c7c04240899bde36c01a28c51ee7"
 
 [[artifacts]]
 version = "go1.9.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9.5.linux-arm64.tar.gz"
 checksum = "sha256:d0bb265559cd8613882e6bbd197a80ed7090684117c6fc6900aa58dea2463715"
 
 [[artifacts]]
 version = "go1.9.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9.4.linux-amd64.tar.gz"
 checksum = "sha256:15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779"
 
 [[artifacts]]
 version = "go1.9.4"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9.4.linux-arm64.tar.gz"
 checksum = "sha256:41a71231e99ccc9989867dce2fcb697921a68ede0bd06fc288ab6c2f56be8864"
 
 [[artifacts]]
 version = "go1.9.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9.3.linux-amd64.tar.gz"
 checksum = "sha256:a4da5f4c07dfda8194c4621611aeb7ceaab98af0b38bfb29e1be2ebb04c3556c"
 
 [[artifacts]]
 version = "go1.9.3"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9.3.linux-arm64.tar.gz"
 checksum = "sha256:065d79964023ccb996e9dbfbf94fc6969d2483fbdeeae6d813f514c5afcd98d9"
 
 [[artifacts]]
 version = "go1.9.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9.2.linux-amd64.tar.gz"
 checksum = "sha256:de874549d9a8d8d8062be05808509c09a88a248e77ec14eb77453530829ac02b"
 
 [[artifacts]]
 version = "go1.9.2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9.2.linux-arm64.tar.gz"
 checksum = "sha256:0016ac65ad8340c84f51bc11dbb24ee8265b0a4597dbfdf8d91776fc187456fa"
 
 [[artifacts]]
 version = "go1.9.2rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9.2rc2.linux-amd64.tar.gz"
 checksum = "sha256:bf28294bc9ac1fe2102a139c49b52d3947953a7aaa2cd52e6bb9772d25611faa"
 
 [[artifacts]]
 version = "go1.9.2rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9.2rc2.linux-arm64.tar.gz"
 checksum = "sha256:eef8ae1ee126ef9d6d53fe3b3ac31b29d91dfd8d972bc808691552f0ce884507"
 
 [[artifacts]]
 version = "go1.9.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9.1.linux-amd64.tar.gz"
 checksum = "sha256:07d81c6b6b4c2dcf1b5ef7c27aaebd3691cdb40548500941f92b221147c5d9c7"
 
 [[artifacts]]
 version = "go1.9.1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9.1.linux-arm64.tar.gz"
 checksum = "sha256:d31ecae36efea5197af271ccce86ccc2baf10d2e04f20d0fb75556ecf0614dad"
 
 [[artifacts]]
 version = "go1.9"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9.linux-amd64.tar.gz"
 checksum = "sha256:d70eadefce8e160638a9a6db97f7192d8463069ab33138893ad3bf31b0650a79"
 
 [[artifacts]]
 version = "go1.9"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9.linux-arm64.tar.gz"
 checksum = "sha256:0958dcf454f7f26d7acc1a4ddc34220d499df845bc2051c14ff8efdf1e3c29a6"
 
 [[artifacts]]
 version = "go1.9rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9rc2.linux-amd64.tar.gz"
 checksum = "sha256:0d17d440f02505d8fbf6becb777175c242486c1d71046705876dcd20e0574002"
 
 [[artifacts]]
 version = "go1.9rc2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9rc2.linux-arm64.tar.gz"
 checksum = "sha256:c53bdbc41fcd980f4ad6e5f216913053709479871cd395990fa4bf4f01c21e7d"
 
 [[artifacts]]
 version = "go1.9rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9rc1.linux-amd64.tar.gz"
 checksum = "sha256:a8ea2ac09878b7a5ac04fe52f144cdc64ab637230638af6975c0f1facbba3ec2"
 
 [[artifacts]]
 version = "go1.9rc1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9rc1.linux-arm64.tar.gz"
 checksum = "sha256:e1d6f224b3abf6d98530f69f7a2802dfbecf696d1c8b25e3885e1f78e7e0d42b"
 
 [[artifacts]]
 version = "go1.9beta2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9beta2.linux-amd64.tar.gz"
 checksum = "sha256:023f778f063d2234e7c95f572a92298b307807693f7e045a88c90ecd7a08f29d"
 
 [[artifacts]]
 version = "go1.9beta2"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9beta2.linux-arm64.tar.gz"
 checksum = "sha256:4e60b704f04441ad97b5a7c660a680225abd59b33b9044731066f2f91c18ddba"
 
 [[artifacts]]
 version = "go1.9beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.9beta1.linux-amd64.tar.gz"
 checksum = "sha256:85719a2c704ad1352052e185c760d7c65b9d8a18b491287a7e5f6775ccc27d3b"
 
 [[artifacts]]
 version = "go1.9beta1"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.9beta1.linux-arm64.tar.gz"
 checksum = "sha256:d6877ab02d9133a51925861af2db76faabe33146ed87225450fd56c6535088ab"
 
 [[artifacts]]
 version = "go1.8.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8.7.linux-amd64.tar.gz"
 checksum = "sha256:de32e8db3dc030e1448a6ca52d87a1e04ad31c6b212007616cfcc87beb0e4d60"
 
 [[artifacts]]
 version = "go1.8.7"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.8.7.linux-arm64.tar.gz"
 checksum = "sha256:804c2e73eca5ce309f2947aaf437fce9f67463b4fb9484f47c95b632d4eeabf6"
 
 [[artifacts]]
 version = "go1.8.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8.6.linux-amd64.tar.gz"
 checksum = "sha256:f558c91c2f6aac7222e0bd83e6dd595b8fac85aaa96e55d15229542eb4aaa1ff"
 
 [[artifacts]]
 version = "go1.8.6"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.8.6.linux-arm64.tar.gz"
 checksum = "sha256:7ed8fd5b4109394e23a6a120686b8ee91806d6f9b16222ca9dbc8778e7a2fbc4"
 
 [[artifacts]]
 version = "go1.8.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8.5.linux-amd64.tar.gz"
 checksum = "sha256:4f8aeea2033a2d731f2f75c4d0a4995b357b22af56ed69b3015f4291fca4d42d"
 
 [[artifacts]]
 version = "go1.8.5"
 os = "linux"
-arch = "aarch64"
+arch = "arm64"
 url = "https://go.dev/dl/go1.8.5.linux-arm64.tar.gz"
 checksum = "sha256:6c552ae1e77c52944e0f9b9034761bd3dcc3fef57dad6d751a53638783b07d2c"
 
 [[artifacts]]
 version = "go1.8.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8.4.linux-amd64.tar.gz"
 checksum = "sha256:0ef737a0aff9742af0f63ac13c97ce36f0bbc8b67385169e41e395f34170944f"
 
 [[artifacts]]
 version = "go1.8.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8.3.linux-amd64.tar.gz"
 checksum = "sha256:1862f4c3d3907e59b04a757cfda0ea7aa9ef39274af99a784f5be843c80c6772"
 
 [[artifacts]]
 version = "go1.8.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8.2.linux-amd64.tar.gz"
 checksum = "sha256:5477d6c9a4f96fa120847fafa88319d7b56b5d5068e41c3587eebe248b939be7"
 
 [[artifacts]]
 version = "go1.8.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8.1.linux-amd64.tar.gz"
 checksum = "sha256:a579ab19d5237e263254f1eac5352efcf1d70b9dacadb6d6bb12b0911ede8994"
 
 [[artifacts]]
 version = "go1.8"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8.linux-amd64.tar.gz"
 checksum = "sha256:53ab94104ee3923e228a2cb2116e5e462ad3ebaeea06ff04463479d7f12d27ca"
 
 [[artifacts]]
 version = "go1.8rc3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8rc3.linux-amd64.tar.gz"
 checksum = "sha256:0ff3faba02ac83920a65b453785771e75f128fbf9ba4ad1d5e72c044103f9c7a"
 
 [[artifacts]]
 version = "go1.8rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8rc2.linux-amd64.tar.gz"
 checksum = "sha256:d62c2d44d0c6b434e3cda12505f3c9fb880757e3396af1e9ba861f7b547cc864"
 
 [[artifacts]]
 version = "go1.8rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8rc1.linux-amd64.tar.gz"
 checksum = "sha256:bb8fe0d81161e4a8b0a8b2145ee5f8a60370baf5d48c07a83f6f09e1ad253bec"
 
 [[artifacts]]
 version = "go1.8beta2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8beta2.linux-amd64.tar.gz"
 checksum = "sha256:4cb9bfb0e82d665871b84070929d6eeb4d51af6bedbc8fdd3df5766e937ef84c"
 
 [[artifacts]]
 version = "go1.8beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.8beta1.linux-amd64.tar.gz"
 checksum = "sha256:768d8d73ccea69c9a0941f9ef2333b1ff8c82120abfcdedd4e91af039c674a8d"
 
 [[artifacts]]
 version = "go1.7.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7.6.linux-amd64.tar.gz"
 checksum = "sha256:ad5808bf42b014c22dd7646458f631385003049ded0bb6af2efc7f1f79fa29ea"
 
 [[artifacts]]
 version = "go1.7.5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7.5.linux-amd64.tar.gz"
 checksum = "sha256:2e4dd6c44f0693bef4e7b46cc701513d74c3cc44f2419bf519d7868b12931ac3"
 
 [[artifacts]]
 version = "go1.7.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7.4.linux-amd64.tar.gz"
 checksum = "sha256:47fda42e46b4c3ec93fa5d4d4cc6a748aa3f9411a2a2b7e08e3a6d80d753ec8b"
 
 [[artifacts]]
 version = "go1.7.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7.3.linux-amd64.tar.gz"
 checksum = "sha256:508028aac0654e993564b6e2014bf2d4a9751e3b286661b0b0040046cf18028e"
 
 [[artifacts]]
 version = "go1.7.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7.1.linux-amd64.tar.gz"
 checksum = "sha256:43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182"
 
 [[artifacts]]
 version = "go1.7"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7.linux-amd64.tar.gz"
 checksum = "sha256:702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95"
 
 [[artifacts]]
 version = "go1.7rc6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7rc6.linux-amd64.tar.gz"
 checksum = "sha256:45e3dfba542927ea58146a5d47a983feb36401ccafeea28a9e0a79534738b154"
 
 [[artifacts]]
 version = "go1.7rc5"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7rc5.linux-amd64.tar.gz"
 checksum = "sha256:2ddf9f553aefe91d96dd3f13be55159869a221fd0111cd211dccf2cab3ee5e4a"
 
 [[artifacts]]
 version = "go1.7rc4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7rc4.linux-amd64.tar.gz"
 checksum = "sha256:b75fa3bd2159754c404e3c83ba333d1ea80cb74de382b409afa6996abf0cc48a"
 
 [[artifacts]]
 version = "go1.7rc3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7rc3.linux-amd64.tar.gz"
 checksum = "sha256:53393c132223415c30ef877cb5c900d989f8a953e864e1119aeaedbca1918144"
 
 [[artifacts]]
 version = "go1.7rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7rc2.linux-amd64.tar.gz"
 checksum = "sha256:145e486499d349757cbb7ae8dfeeea5d7a76f146f6c8880173fe3d0aacc5dd42"
 
 [[artifacts]]
 version = "go1.7rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7rc1.linux-amd64.tar.gz"
 checksum = "sha256:afe956b6d323c68fbd851f4e962f26f16dde61d7caa1de1a8408c7de0b6034aa"
 
 [[artifacts]]
 version = "go1.7beta2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7beta2.linux-amd64.tar.gz"
 checksum = "sha256:688f895b51def9e065fb2610ff91afcb2b0d9637233b74130c8ca331d35d5ca5"
 
 [[artifacts]]
 version = "go1.7beta1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.7beta1.linux-amd64.tar.gz"
 checksum = "sha256:a55e718935e2be1d5b920ed262fd06885d2d7fc4eab7722aa02c205d80532e3b"
 
 [[artifacts]]
 version = "go1.6.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.6.4.linux-amd64.tar.gz"
 checksum = "sha256:b58bf5cede40b21812dfa031258db18fc39746cc0972bc26dae0393acc377aaf"
 
 [[artifacts]]
 version = "go1.6.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.6.3.linux-amd64.tar.gz"
 checksum = "sha256:cdde5e08530c0579255d6153b08fdb3b8e47caabbe717bc7bcd7561275a87aeb"
 
 [[artifacts]]
 version = "go1.6.2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.6.2.linux-amd64.tar.gz"
 checksum = "sha256:e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a"
 
 [[artifacts]]
 version = "go1.6.1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.6.1.linux-amd64.tar.gz"
 checksum = "sha256:6d894da8b4ad3f7f6c295db0d73ccc3646bce630e1c43e662a0120681d47e988"
 
 [[artifacts]]
 version = "go1.6"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.6.linux-amd64.tar.gz"
 checksum = "sha256:5470eac05d273c74ff8bac7bef5bad0b5abbd1c4052efbdbc8db45332e836b0b"
 
 [[artifacts]]
 version = "go1.6rc2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.6rc2.linux-amd64.tar.gz"
 checksum = "sha256:9c19fa0fe32ee9bff79123d47147a5fd15fec451806bf5644a01173a86a8a4b9"
 
 [[artifacts]]
 version = "go1.6rc1"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.6rc1.linux-amd64.tar.gz"
 checksum = "sha256:6a8aeab9548faf933a66dafeb809bd8623c5bba1ca9626c2f28ef619b5723218"
 
 [[artifacts]]
 version = "go1.6beta2"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.6beta2.linux-amd64.tar.gz"
 checksum = "sha256:7ddf9797c7baaac2c16eed1a8d42f9a446223301c7dc8771ea805f211828e6a5"
 
 [[artifacts]]
 version = "go1.5.4"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.5.4.linux-amd64.tar.gz"
 checksum = "sha256:a3358721210787dc1e06f5ea1460ae0564f22a0fbd91be9dcd947fb1d19b9560"
 
 [[artifacts]]
 version = "go1.5.3"
 os = "linux"
-arch = "x86_64"
+arch = "amd64"
 url = "https://go.dev/dl/go1.5.3.linux-amd64.tar.gz"
 checksum = "sha256:43afe0c5017e502630b1aea4d44b8a7f059bf60d7f29dfd58db454d4e4e0ae53"

--- a/buildpacks/go/src/tgz.rs
+++ b/buildpacks/go/src/tgz.rs
@@ -126,7 +126,7 @@ mod tests {
         let artifact = Artifact::<String, Sha256> {
             version: "0.0.1".to_string(),
             os: Os::Linux,
-            arch: Arch::X86_64,
+            arch: Arch::Amd64,
             url: "https://mirrors.edge.kernel.org/pub/software/scm/git/git-0.01.tar.gz".to_string(),
             checksum: Checksum::try_from(
                 "9bdf8a4198b269c5cbe4263b1f581aae885170a6cb93339a2033cb468e57dcd3".to_string(),

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -205,11 +205,11 @@ fn test_go_artifact_caching() {
         |ctx| {
             assert_contains!(
                 ctx.pack_stdout,
-                "Installing go1.16.15 (linux-x86_64) from https://go.dev/dl/go1.16.15.linux-amd64.tar.gz",
+                "Installing go1.16.15 (linux-amd64) from https://go.dev/dl/go1.16.15.linux-amd64.tar.gz",
             );
             let config = ctx.config.clone();
             ctx.rebuild(config, |ctx| {
-                assert_contains!(ctx.pack_stdout, "Reusing go1.16.15 (linux-x86_64)");
+                assert_contains!(ctx.pack_stdout, "Reusing go1.16.15 (linux-amd64)");
             });
         },
     );

--- a/common/go-utils/src/inv.rs
+++ b/common/go-utils/src/inv.rs
@@ -97,7 +97,7 @@ mod tests {
         Artifact {
             version: GoVersion::try_from("1.7.2".to_string()).unwrap(),
             os: Os::Linux,
-            arch: Arch::X86_64,
+            arch: Arch::Amd64,
             url: String::from("foo"),
             checksum: Checksum::try_from(
                 "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890".to_string(),

--- a/common/go-utils/src/inv.rs
+++ b/common/go-utils/src/inv.rs
@@ -110,7 +110,7 @@ mod tests {
     fn test_artifact_display_format() {
         let artifact = create_artifact();
 
-        assert_eq!("1.7.2 (linux-x86_64)", artifact.to_string());
+        assert_eq!("1.7.2 (linux-amd64)", artifact.to_string());
     }
 
     #[test]

--- a/common/inventory-utils/src/inv.rs
+++ b/common/inventory-utils/src/inv.rs
@@ -93,8 +93,8 @@ impl FromStr for Os {
 impl Display for Arch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Arch::X86_64 => write!(f, "x86_64"),
-            Arch::Aarch64 => write!(f, "aarch64"),
+            Arch::X86_64 => write!(f, "amd64"),
+            Arch::Aarch64 => write!(f, "arm64"),
         }
     }
 }
@@ -163,7 +163,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_arch_display_format() {
-        let archs = [(Arch::X86_64, "x86_64"), (Arch::Aarch64, "aarch64")];
+        let archs = [(Arch::X86_64, "amd64"), (Arch::Aarch64, "arm64")];
 
         for (input, expected) in archs {
             assert_eq!(expected, input.to_string());
@@ -206,7 +206,7 @@ mod tests {
     #[test]
     fn test_artifact_display() {
         assert_eq!(
-            "foo (linux-aarch64)",
+            "foo (linux-arm64)",
             create_artifact("foo", Os::Linux, Arch::Aarch64).to_string()
         );
     }

--- a/common/inventory-utils/src/inv.rs
+++ b/common/inventory-utils/src/inv.rs
@@ -63,8 +63,8 @@ pub enum Os {
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Arch {
-    X86_64,
-    Aarch64,
+    Amd64,
+    Arm64,
 }
 
 impl Display for Os {
@@ -93,8 +93,8 @@ impl FromStr for Os {
 impl Display for Arch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Arch::X86_64 => write!(f, "amd64"),
-            Arch::Aarch64 => write!(f, "arm64"),
+            Arch::Amd64 => write!(f, "amd64"),
+            Arch::Arm64 => write!(f, "arm64"),
         }
     }
 }
@@ -108,8 +108,8 @@ impl FromStr for Arch {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "amd64" | "x86_64" => Ok(Arch::X86_64),
-            "arm64" | "aarch64" => Ok(Arch::Aarch64),
+            "amd64" | "x86_64" => Ok(Arch::Amd64),
+            "arm64" | "aarch64" => Ok(Arch::Arm64),
             _ => Err(UnsupportedArchError(s.to_string())),
         }
     }
@@ -163,7 +163,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_arch_display_format() {
-        let archs = [(Arch::X86_64, "amd64"), (Arch::Aarch64, "arm64")];
+        let archs = [(Arch::Amd64, "amd64"), (Arch::Arm64, "arm64")];
 
         for (input, expected) in archs {
             assert_eq!(expected, input.to_string());
@@ -173,10 +173,10 @@ mod tests {
     #[test]
     fn test_arch_parsing() {
         let archs = [
-            ("amd64", Arch::X86_64),
-            ("arm64", Arch::Aarch64),
-            ("x86_64", Arch::X86_64),
-            ("aarch64", Arch::Aarch64),
+            ("amd64", Arch::Amd64),
+            ("arm64", Arch::Arm64),
+            ("x86_64", Arch::Amd64),
+            ("aarch64", Arch::Arm64),
         ];
         for (input, expected) in archs {
             assert_eq!(expected, input.parse::<Arch>().unwrap());
@@ -207,7 +207,7 @@ mod tests {
     fn test_artifact_display() {
         assert_eq!(
             "foo (linux-arm64)",
-            create_artifact("foo", Os::Linux, Arch::Aarch64).to_string()
+            create_artifact("foo", Os::Linux, Arch::Arm64).to_string()
         );
     }
 
@@ -222,9 +222,9 @@ mod tests {
         assert_eq!(
             "foo",
             &resolve(
-                &[create_artifact("foo", Os::Linux, Arch::Aarch64)],
+                &[create_artifact("foo", Os::Linux, Arch::Arm64)],
                 Os::Linux,
-                Arch::Aarch64,
+                Arch::Arm64,
                 &String::from("foo")
             )
             .expect("should resolve matching artifact")
@@ -235,9 +235,9 @@ mod tests {
     #[test]
     fn test_dont_resolve_artifact_with_wrong_arch() {
         assert!(resolve(
-            &[create_artifact("foo", Os::Linux, Arch::Aarch64)],
+            &[create_artifact("foo", Os::Linux, Arch::Arm64)],
             Os::Linux,
-            Arch::X86_64,
+            Arch::Amd64,
             &String::from("foo")
         )
         .is_none());
@@ -246,9 +246,9 @@ mod tests {
     #[test]
     fn test_dont_resolve_artifact_with_wrong_version() {
         assert!(resolve(
-            &[create_artifact("foo", Os::Linux, Arch::Aarch64)],
+            &[create_artifact("foo", Os::Linux, Arch::Arm64)],
             Os::Linux,
-            Arch::Aarch64,
+            Arch::Arm64,
             &String::from("bar")
         )
         .is_none());


### PR DESCRIPTION
Fixes https://github.com/heroku/buildpacks-go/issues/243