### PR TITLE
Remove Version marker trait

### DIFF
--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -1,4 +1,4 @@
-use heroku_inventory_utils::inv::{Version, VersionRequirement};
+use heroku_inventory_utils::inv::VersionRequirement;
 use regex::Regex;
 use semver;
 use serde::{Deserialize, Serialize};
@@ -39,8 +39,6 @@ pub struct GoVersion {
     #[serde(skip)]
     semantic_version: semver::Version,
 }
-
-impl Version for GoVersion {}
 
 impl Display for GoVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/common/inventory-utils/Cargo.toml
+++ b/common/inventory-utils/Cargo.toml
@@ -8,7 +8,7 @@ workspace = true
 
 [dependencies]
 hex = "0.4.3"
-semver = "1"
+semver = {version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10.8"
 thiserror = "1"

--- a/common/inventory-utils/src/inv.rs
+++ b/common/inventory-utils/src/inv.rs
@@ -7,18 +7,16 @@ use std::fs;
 use std::hash::Hash;
 use std::{fmt::Display, str::FromStr};
 
-pub trait Version: Serialize + DeserializeOwned {}
-
 /// Represents an inventory of artifacts.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Inventory<V, D> {
-    #[serde(bound = "V: Version, D: Name")]
+    #[serde(bound = "V: Serialize + DeserializeOwned, D: Name")]
     pub artifacts: Vec<Artifact<V, D>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Artifact<V, D> {
-    #[serde(bound = "V: Version")]
+    #[serde(bound = "V: Serialize + DeserializeOwned")]
     pub version: V,
     pub os: Os,
     pub arch: Arch,
@@ -134,7 +132,7 @@ pub enum ReadInventoryError {
 /// file contents is not formatted properly.
 pub fn read_inventory_file<V, D>(path: &str) -> Result<Inventory<V, D>, ReadInventoryError>
 where
-    V: Version,
+    V: Serialize + DeserializeOwned,
     D: Name,
 {
     toml::from_str(&fs::read_to_string(path)?).map_err(ReadInventoryError::Parse)

--- a/common/inventory-utils/src/semvrs.rs
+++ b/common/inventory-utils/src/semvrs.rs
@@ -1,9 +1,7 @@
-use crate::inv::{Version, VersionRequirement};
+use crate::inv::VersionRequirement;
 
 impl VersionRequirement<semver::Version> for semver::VersionReq {
     fn satisfies(&self, version: &semver::Version) -> bool {
         self.matches(version)
     }
 }
-
-impl Version for semver::Version {}

--- a/common/inventory-utils/src/semvrs.rs
+++ b/common/inventory-utils/src/semvrs.rs
@@ -1,7 +1,9 @@
-use crate::inv::VersionRequirement;
+use crate::inv::{Version, VersionRequirement};
 
 impl VersionRequirement<semver::Version> for semver::VersionReq {
     fn satisfies(&self, version: &semver::Version) -> bool {
         self.matches(version)
     }
 }
+
+impl Version for semver::Version {}


### PR DESCRIPTION
This allows use of for instance `semver::Version` and `semver::VersionReq` out of the box for users of the shared library code.