### PR TITLE
`arm64` and multi-arch support

### DIFF
--- a/buildpacks/go/CHANGELOG.md
+++ b/buildpacks/go/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for `arm64` and multi-arch images.
+
 ## [0.2.1] - 2024-04-05
 
 - Added go1.21.9 (linux-aarch64), go1.21.9 (linux-x86_64), go1.22.2 (linux-aarch64), go1.22.2 (linux-x86_64).

--- a/buildpacks/go/CHANGELOG.md
+++ b/buildpacks/go/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add support for `arm64` and multi-arch images. ([#261](https://github.com/heroku/buildpacks-go/pull/261))
+### Added
+
+- Support for `arm64` and multi-arch images. ([#261](https://github.com/heroku/buildpacks-go/pull/261))
 
 ## [0.2.1] - 2024-04-05
 

--- a/buildpacks/go/CHANGELOG.md
+++ b/buildpacks/go/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add support for `arm64` and multi-arch images.
+- Add support for `arm64` and multi-arch images. ([#261](https://github.com/heroku/buildpacks-go/pull/261))
 
 ## [0.2.1] - 2024-04-05
 


### PR DESCRIPTION
There's really nothing to do here except add a changelog entry; the `buildpack.toml` already has both targets. The next release will be published as multi-arch, since https://github.com/heroku/languages-github-actions/pull/194 is merged.