### PR TITLE
Use pub-hk-ubuntu-22.04-arm-small

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
   integration-test:
     name: integration-tests ${{ matrix.builder }} / ${{ matrix.arch }}
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-22.04-arm-large' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-22.04-arm-small' || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch: ["amd64"]
@@ -53,14 +53,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      # The beta ARM64 runners don't yet ship with the normal installed tools.
-      - name: Install Docker, Rust and development libs (ARM64 only)
+      - name: Install Rust and development libs (ARM64 only)
         if: matrix.arch == 'arm64'
         run: |
           sudo apt-get update --error-on=any
-          sudo apt-get install -y --no-install-recommends acl docker.io docker-buildx libc6-dev
-          sudo usermod -aG docker $USER
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
+          sudo apt-get install -y --no-install-recommends libc6-dev
           curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
           echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
       - name: Install musl-tools


### PR DESCRIPTION
Smaller runners are more plentiful, and we no longer need to install Docker, either!