### PR TITLE
Fix issues with Docker Hub rate limits in CI

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
         run: cargo fmt -- --check
 
   unit-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
 
   integration-test:
     name: integration-tests ${{ matrix.builder }} / ${{ matrix.arch }}
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-22.04-arm-small' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         arch: ["amd64"]
@@ -63,8 +63,18 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.3
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.7.2
+      # The images are pulled up front to prevent duplicate pulls due to the tests being run concurrently.
       - name: Pull builder image
         run: docker pull ${{ matrix.builder }}
+      - name: Pull run image
+        # Using `docker inspect` rather than `pack builder inspect` since the latter makes
+        # additional requests to Docker Hub even when the image is available locally.
+        run: |
+          RUN_IMAGE=$(
+            docker inspect --format='{{index .Config.Labels "io.buildpacks.builder.metadata"}}' '${{ matrix.builder }}' \
+              | jq --exit-status --raw-output '.stack.runImage.image'
+          )
+          docker pull "${RUN_IMAGE}"
       - name: Run integration tests
         env:
           INTEGRATION_TEST_BUILDER: ${{ matrix.builder }}

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   update-go-inventory:
     name: Update Go Inventory
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - uses: actions/create-github-app-token@v1
         id: generate-token


### PR DESCRIPTION
Similar to the Node.js CNB repo, this repo is occasionally hitting Docker Hub rate limit errors on the ARM jobs in the matrix like so:
https://github.com/heroku/buildpacks-go/actions/runs/9796334219/job/27051359595#step:8:10

These are due to the fact that the `pub-hk-ubuntu-22.04-arm-small` ARM runner also has a static IP enabled, which means all traffic from any runners in that group go through a single load balancer with the fixed IP. This not only causes throughput/reliability issues, but means that we're more likely to hit the Docker Hub rate limit.

As such, we requested the creation of some new runner groups that separate out the "need a fixed IP for writes" vs "need more compute or an ARM CPU" use-cases. As an added bonus these groups are also using Ubuntu 24.04. See:
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZR57becb9df8d94f80b132168fd
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

This PR switches to those new groups, and also adds pre-pulling of the run image to prevent it being pulled multiple times when the tests run (`libcnb-test` uses `--pull-policy if-not-present` with `pack build`, but the tests run concurrently so on first run multiple pulls will otherwise be performed). See also:
https://github.com/heroku/buildpacks-python/pull/223

GUS-W-16238120.