### PR TITLE
Use MultiGzDecoder for better download reliability

### DIFF
--- a/buildpacks/go/CHANGELOG.md
+++ b/buildpacks/go/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Adjust Go distribution tarball download process for improved reliability.
+
 ## [0.4.3] - 2024-08-13
 
 - Added go1.23.0 (linux-amd64), go1.23.0 (linux-arm64).

--- a/buildpacks/go/src/tgz.rs
+++ b/buildpacks/go/src/tgz.rs
@@ -1,4 +1,4 @@
-use flate2::read::GzDecoder;
+use flate2::read::MultiGzDecoder;
 use sha2::{
     digest::{generic_array::GenericArray, OutputSizeUser},
     Digest,
@@ -55,7 +55,7 @@ pub(crate) fn fetch_strip_filter_extract_verify<'a, D: Digest, V>(
         .map_err(Box::new)?
         .into_reader();
 
-    let mut archive = Archive::new(GzDecoder::new(DigestingReader::new(body, D::new())));
+    let mut archive = Archive::new(MultiGzDecoder::new(DigestingReader::new(body, D::new())));
     let filters: Vec<&str> = filter_prefixes.into_iter().collect();
     for entry in archive.entries().map_err(Error::Entries)? {
         let mut file = entry.map_err(Error::Entry)?;


### PR DESCRIPTION
@colincasey has a suspicion that the `MultiGzDecoder` handles trailing garbage better. Perhaps this will resolve some of the intermittent download failures seen in this buildpack.