### PR TITLE
Don't set processes when Procfile is present

### DIFF
--- a/buildpacks/go/CHANGELOG.md
+++ b/buildpacks/go/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Now prefers processes set by Procfile, and no longer adds it's own processes if a Procfile is present.
+
 ## [0.4.7] - 2024-12-06
 
 - Added go1.22.10 (linux-amd64), go1.22.10 (linux-arm64), go1.23.4 (linux-amd64), go1.23.4 (linux-arm64).

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -140,8 +140,10 @@ impl Buildpack for GoBuildpack {
         cmd::go_install(&packages, &go_env).map_err(GoBuildpackError::GoBuild)?;
 
         let mut procs: Vec<Process> = vec![];
-        if !Path::exists(&context.app_dir.join("Procfile")) {
-            log_header("Setting launch table");
+        if Path::exists(&context.app_dir.join("Procfile")) {
+            log_info("Skipping launch process registration (Procfile detected)");
+        } else {
+            log_header("Registering launch processes");
             procs = proc::build_procs(&packages).map_err(GoBuildpackError::Proc)?;
             log_info("Detected processes:");
             for proc in &procs {

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -11,7 +11,7 @@ use layers::dist::{DistLayer, DistLayerError};
 use layers::target::{TargetLayer, TargetLayerError};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::build_plan::BuildPlanBuilder;
-use libcnb::data::launch::LaunchBuilder;
+use libcnb::data::launch::{LaunchBuilder, Process};
 use libcnb::data::layer_name;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericMetadata;
@@ -139,11 +139,14 @@ impl Buildpack for GoBuildpack {
         }
         cmd::go_install(&packages, &go_env).map_err(GoBuildpackError::GoBuild)?;
 
-        log_header("Setting launch table");
-        let procs = proc::build_procs(&packages).map_err(GoBuildpackError::Proc)?;
-        log_info("Detected processes:");
-        for proc in &procs {
-            log_info(format!("  - {}: {}", proc.r#type, proc.command.join(" ")));
+        let mut procs: Vec<Process> = vec![];
+        if !Path::exists(&context.app_dir.join("Procfile")) {
+            log_header("Setting launch table");
+            procs = proc::build_procs(&packages).map_err(GoBuildpackError::Proc)?;
+            log_info("Detected processes:");
+            for proc in &procs {
+                log_info(format!("  - {}: {}", proc.r#type, proc.command.join(" ")));
+            }
         }
 
         BuildResultBuilder::new()

--- a/buildpacks/go/tests/fixtures/procfile_http_123/Procfile
+++ b/buildpacks/go/tests/fixtures/procfile_http_123/Procfile
@@ -1,0 +1,1 @@
+web: procfile_http_123

--- a/buildpacks/go/tests/fixtures/procfile_http_123/go.mod
+++ b/buildpacks/go/tests/fixtures/procfile_http_123/go.mod
@@ -1,0 +1,3 @@
+module example.com/procfile_http_123
+
+go 1.23

--- a/buildpacks/go/tests/fixtures/procfile_http_123/main.go
+++ b/buildpacks/go/tests/fixtures/procfile_http_123/main.go
@@ -1,0 +1,21 @@
+// +build heroku
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"net/http"
+)
+
+func root(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(w, "procfile_http_123")
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" { port = "8080" }
+
+	http.HandleFunc("/", root)
+	http.ListenAndServe(":" + port, nil)
+}

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -121,6 +121,7 @@ fn test_worker_http_118() {
         &[
             "Detected Go version requirement: ~1.18.1",
             "Installing go1.18.",
+            "Detected processes",
             "example.com/worker_http_118/cmd/web",
             "example.com/worker_http_118/cmd/worker",
         ],
@@ -139,6 +140,18 @@ fn test_basic_http_119() {
         ],
         &[],
     );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn test_procfile_http_123() {
+    let build_config: BuildConfig = IntegrationTestConfig::new("procfile_http_123").into();
+    TestRunner::default().build(build_config, |ctx| {
+        assert_contains!(ctx.pack_stdout, "Detected Go version requirement: =1.23");
+        assert_contains!(ctx.pack_stdout, "Installing go1.23.");
+        assert_not_contains!(ctx.pack_stdout, "Setting launch table");
+        assert_not_contains!(ctx.pack_stdout, "Detected processes:");
+    });
 }
 
 #[test]

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -121,7 +121,7 @@ fn test_worker_http_118() {
         &[
             "Detected Go version requirement: ~1.18.1",
             "Installing go1.18.",
-            "Detected processes",
+            "Detected processes:",
             "example.com/worker_http_118/cmd/web",
             "example.com/worker_http_118/cmd/worker",
         ],
@@ -149,7 +149,8 @@ fn test_procfile_http_123() {
     TestRunner::default().build(build_config, |ctx| {
         assert_contains!(ctx.pack_stdout, "Detected Go version requirement: =1.23");
         assert_contains!(ctx.pack_stdout, "Installing go1.23.");
-        assert_not_contains!(ctx.pack_stdout, "Setting launch table");
+        assert_contains!(ctx.pack_stdout, "Skipping launch process registration");
+        assert_not_contains!(ctx.pack_stdout, "Registering launch processes");
         assert_not_contains!(ctx.pack_stdout, "Detected processes:");
     });
 }


### PR DESCRIPTION
Customers are often surprised and sometimes annoyed when this buildpack adds processes not in the `Procfile`. This prevents adding processes when a `Procfile` is present. 

In the future, I'd like to change this conditional to be dependent on `heroku/procfile` contributing, rather than the specific `Procfile` file.

Related: #85

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001z1TA7YAM/view)