### PR TITLE
[Stacked] Non-consuming bullet_stream alternative

### DIFF
--- a/buildpacks/go/src/cmd.rs
+++ b/buildpacks/go/src/cmd.rs
@@ -1,7 +1,7 @@
-use bullet_stream::{global::print, state::SubBullet, style, Print};
+use bullet_stream::{global::print, style};
 use fun_run::{CmdError, CommandWithName};
 use libcnb::Env;
-use std::{io::Write, process::Command};
+use std::process::Command;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {

--- a/buildpacks/go/src/cmd.rs
+++ b/buildpacks/go/src/cmd.rs
@@ -1,5 +1,5 @@
-use bullet_stream::{global::print, style};
-use fun_run::{CmdError, CommandWithName};
+use bullet_stream::global::print;
+use fun_run::CmdError;
 use libcnb::Env;
 use std::process::Command;
 
@@ -28,12 +28,9 @@ pub(crate) fn go_install<S: AsRef<str>>(packages: &[S], go_env: &Env) -> Result<
     let mut cmd = Command::new("go");
     cmd.args(args).envs(go_env);
 
-    print::sub_stream_with(
-        format!("Running {}", style::command(cmd.name())),
-        |stdout, stderr| cmd.stream_output(stdout, stderr),
-    )
-    .map(|_| ())
-    .map_err(Error::FailedCommand)
+    print::sub_stream_cmd(cmd)
+        .map(|_| ())
+        .map_err(Error::FailedCommand)
 }
 
 /// Run `go list -tags -f {{ .ImportPath }} ./...`. Useful for listing
@@ -57,16 +54,13 @@ pub(crate) fn go_list(go_env: &Env) -> Result<Vec<String>, Error> {
     ])
     .envs(go_env);
 
-    print::sub_stream_with(
-        format!("Running {}", style::command(cmd.name())),
-        |stdout, stderr| cmd.stream_output(stdout, stderr),
-    )
-    .map_err(Error::FailedCommand)
-    .map(|output| {
-        output
-            .stdout_lossy()
-            .split_whitespace()
-            .map(|s| s.trim().to_string())
-            .collect()
-    })
+    print::sub_stream_cmd(cmd)
+        .map_err(Error::FailedCommand)
+        .map(|output| {
+            output
+                .stdout_lossy()
+                .split_whitespace()
+                .map(|s| s.trim().to_string())
+                .collect()
+        })
 }

--- a/buildpacks/go/src/layers/build.rs
+++ b/buildpacks/go/src/layers/build.rs
@@ -62,7 +62,7 @@ pub(crate) fn call(
         }
     }
 
-    Ok(layer_ref.read_env()?)
+    layer_ref.read_env()
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, CacheDiff, TryMigrate)]

--- a/buildpacks/go/src/layers/dist.rs
+++ b/buildpacks/go/src/layers/dist.rs
@@ -1,7 +1,6 @@
 use crate::{tgz, GoBuildpack, GoBuildpackError};
 use bullet_stream::global::print;
-use bullet_stream::state::SubBullet;
-use bullet_stream::{style, Print};
+use bullet_stream::style;
 use cache_diff::CacheDiff;
 use commons::layer::diff_migrate::DiffMigrateLayer;
 use heroku_go_utils::vrs::GoVersion;
@@ -14,7 +13,6 @@ use libherokubuildpack::inventory::artifact::Artifact;
 use magic_migrate::TryMigrate;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-use std::io::Write;
 
 pub(crate) fn call(
     context: &BuildContext<GoBuildpack>,

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -99,8 +99,8 @@ impl Buildpack for GoBuildpack {
             )?
         };
 
-        (build_output, go_env) = {
-            let bullet = build_output.bullet("Go binaries");
+        go_env = {
+            print::bullet("Go binaries");
             if context
                 .app_dir
                 .join("vendor")
@@ -108,14 +108,11 @@ impl Buildpack for GoBuildpack {
                 .fs_err_try_exists()
                 .map_err(GoBuildpackError::FsTryExist)?
             {
-                (
-                    bullet.sub_bullet("Using vendored Go modules").done(),
-                    go_env,
-                )
+                print::sub_bullet("Using vendored Go modules");
+                go_env
             } else {
-                layers::deps::call(&context, bullet, &layers::deps::Metadata::new(1.0)).map(
-                    |(bullet, layer_env)| (bullet.done(), layer_env.apply(Scope::Build, &go_env)),
-                )?
+                layers::deps::call(&context, &layers::deps::Metadata::new(1.0))
+                    .map(|layer_env| layer_env.apply(Scope::Build, &go_env))?
             }
         };
 

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -5,7 +5,7 @@ mod proc;
 mod tgz;
 
 use bullet_stream::global::print;
-use bullet_stream::{style, Print};
+use bullet_stream::style;
 use fs_err::PathExt;
 use heroku_go_utils::vrs::GoVersion;
 use layers::build::BuildLayerError;

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -141,14 +141,12 @@ impl Buildpack for GoBuildpack {
                 layer_ref.read_env()?.apply(Scope::Build, &go_env),
             )
         };
-        (build_output, go_env) = {
-            layers::build::call(
-                &context,
-                build_output.bullet("Go build cache"),
-                &layers::build::Metadata::new(&artifact.version, &context.target),
-            )
-            .map(|(bullet, layer_env)| (bullet.done(), layer_env.apply(Scope::Build, &go_env)))?
-        };
+        print::bullet("Go build cache");
+        go_env = layers::build::call(
+            &context,
+            &layers::build::Metadata::new(&artifact.version, &context.target),
+        )
+        .map(|layer_env| layer_env.apply(Scope::Build, &go_env))?;
 
         print::bullet("Go module resolution");
         let packages = if let Some(packages) = config.packages {

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -150,11 +150,12 @@ impl Buildpack for GoBuildpack {
             .map(|(bullet, layer_env)| (bullet.done(), layer_env.apply(Scope::Build, &go_env)))?
         };
 
-        let bullet = build_output.bullet("Go module resolution");
-        let (_, packages) = if let Some(packages) = config.packages {
-            (bullet.sub_bullet("Found packages in go.mod"), packages)
+        print::bullet("Go module resolution");
+        let packages = if let Some(packages) = config.packages {
+            print::sub_bullet("Found packages in go.mod");
+            packages
         } else {
-            cmd::go_list(bullet, &go_env).map_err(GoBuildpackError::GoList)?
+            cmd::go_list(&go_env).map_err(GoBuildpackError::GoList)?
         };
 
         print::bullet("Packages found");

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -119,7 +119,7 @@ impl Buildpack for GoBuildpack {
             }
         };
 
-        (build_output, go_env) = {
+        go_env = {
             let layer_ref = context.uncached_layer(
                 layer_name!("go_target"),
                 UncachedLayerDefinition {
@@ -136,11 +136,10 @@ impl Buildpack for GoBuildpack {
                 "GOBIN",
                 layer_ref.path().join("bin"),
             ))?;
-            (
-                build_output,
-                layer_ref.read_env()?.apply(Scope::Build, &go_env),
-            )
+
+            layer_ref.read_env()?.apply(Scope::Build, &go_env)
         };
+
         print::bullet("Go build cache");
         go_env = layers::build::call(
             &context,

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -60,7 +60,7 @@ impl Buildpack for GoBuildpack {
 
     #[allow(clippy::too_many_lines)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-        let mut build_output = Print::global().h2("Heroku Go Buildpack");
+        print::h2("Heroku Go Buildpack");
         let started = Instant::now();
         let mut go_env = Env::new();
         env::vars()
@@ -69,14 +69,14 @@ impl Buildpack for GoBuildpack {
                 go_env.insert(k, v);
             });
 
-        let mut bullet = build_output.bullet("Go version");
+        print::bullet("Go version");
         let inv: Inventory<GoVersion, Sha256, Option<()>> =
             toml::from_str(INVENTORY).map_err(GoBuildpackError::InventoryParse)?;
         let go_mod = context.app_dir.join("go.mod");
         let config = cfg::read_gomod_config(&go_mod).map_err(GoBuildpackError::GoModConfig)?;
         let requirement = config.version.unwrap_or_default();
 
-        bullet = bullet.sub_bullet(format!(
+        print::sub_bullet(format!(
             "Detected requirement {req} (from {file})",
             req = style::value(requirement.to_string()),
             file = go_mod.display()
@@ -88,7 +88,7 @@ impl Buildpack for GoBuildpack {
         }
         .ok_or(GoBuildpackError::VersionResolution(requirement.clone()))?;
 
-        bullet = bullet.sub_bullet(format!(
+        print::sub_bullet(format!(
             "Resolved to {}",
             style::value(artifact.version.to_string()),
         ));

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -93,11 +93,8 @@ impl Buildpack for GoBuildpack {
             style::value(artifact.version.to_string()),
         ));
 
-        (build_output, go_env) = {
-            layers::dist::call(&context, bullet, &layers::dist::Metadata::new(artifact)).map(
-                |(bullet, layer_env)| (bullet.done(), layer_env.apply(Scope::Build, &go_env)),
-            )?
-        };
+        go_env = layers::dist::call(&context, &layers::dist::Metadata::new(artifact))
+            .map(|layer_env| layer_env.apply(Scope::Build, &go_env))?;
 
         go_env = {
             print::bullet("Go binaries");

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -151,15 +151,15 @@ impl Buildpack for GoBuildpack {
         };
 
         let bullet = build_output.bullet("Go module resolution");
-        let (bullet, packages) = if let Some(packages) = config.packages {
+        let (_, packages) = if let Some(packages) = config.packages {
             (bullet.sub_bullet("Found packages in go.mod"), packages)
         } else {
             cmd::go_list(bullet, &go_env).map_err(GoBuildpackError::GoList)?
         };
 
-        let mut bullet = bullet.done().bullet("Packages found");
+        print::bullet("Packages found");
         for pkg in &packages {
-            bullet = bullet.sub_bullet(style::value(pkg));
+            print::sub_bullet(style::value(pkg));
         }
 
         print::bullet("Go install");

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -162,14 +162,10 @@ impl Buildpack for GoBuildpack {
             bullet = bullet.sub_bullet(style::value(pkg));
         }
 
-        _ = {
-            bullet = cmd::go_install(bullet.done().bullet("Go install"), &packages, &go_env)
-                .map_err(GoBuildpackError::GoBuild)?;
-            bullet.done()
-        };
+        print::bullet("Go install");
+        cmd::go_install(&packages, &go_env).map_err(GoBuildpackError::GoBuild)?;
 
         print::bullet("Default processes");
-
         let procs = if Path::exists(&context.app_dir.join("Procfile")) {
             print::sub_bullet("Skipping (Procfile detected)");
             Vec::new()


### PR DESCRIPTION
This PR plays on top of https://github.com/heroku/buildpacks-go/pull/327 and demonstrates the difference between the two APIs. 

It feels much less cumbersome to use, but the delta in terms of actual code reduction is smaller than I would have guessed, just -37 lines.: 

<img width="129" alt="image" src="https://github.com/user-attachments/assets/90729ab1-8544-4c2d-90da-a31431bbbee3" />


