### PR TITLE
Disallow deprecations, now that they are fixed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,6 @@ rust-version = "1.84"
 edition = "2021"
 
 [workspace.lints.rust]
-# Temporarily allow use of deprecated items until all buildpacks migrated away
-# from the trait based layer API.
-deprecated = "allow"
 unreachable_pub = "warn"
 unsafe_code = "warn"
 unused_crate_dependencies = "warn"


### PR DESCRIPTION
Now that the trait based layer API is no longer in use, we don't need to allow deprecations anymore.