### PR TITLE
Update to libcnb.rs 0.28; instrument go_download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "globset"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +489,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "tracing",
  "ureq",
 ]
 
@@ -750,9 +757,9 @@ checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libcnb"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4c8b7af2e8c24d9830f2f58c3fb95f8fdbf79eb723f9ee395bad6cde21a329"
+checksum = "40fc93c450371f2eda5814402e85618ab607bd505edbcd41bd739c436bf1e4d1"
 dependencies = [
  "futures-core",
  "libcnb-common",
@@ -765,13 +772,16 @@ dependencies = [
  "serde_json",
  "thiserror",
  "toml",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "libcnb-common"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8494d5b5ab58eaaa6667af8a1369baa9af865d5d832d3b5c02e199c96a11c81"
+checksum = "c5ec4c597affc28524b3607cd78ba4a887f29caf9e853b9323a0d1f19a58778b"
 dependencies = [
  "serde",
  "thiserror",
@@ -780,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-data"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b932cf489d324c1d058c07c46985089ec3581c917d62f174ef8e070ca73a2ae"
+checksum = "45a88b9eadbef6feb8b4d5b4d276d8609feebe2129319a8b02e56caa73aaa5c1"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
@@ -794,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0f4810252944e81b6b7c557e15de9c40bf065ea547f7b2705fe0b3f75a6001"
+checksum = "958d354fa93f426b43b34078d673b9f3edb238f81e1538d565f256905d3a02b3"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -811,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f186e2426b6997db115f4bdcea541cfbb23b60e38c2dd89facf1dbcbe47953"
+checksum = "b0a8078b44fda0cc6f78008af3aafc1944c56c19cbdbd34b510c2ab966130330"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
@@ -823,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-test"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36b1ad9039f3173fa6fe7188270827dbc51336a767eb54847b2b0e896eeb9fa"
+checksum = "2383d9a8c27f201cf49019b9d9a60b307665ddc7d251aab6dda4d64744af301d"
 dependencies = [
  "fastrand",
  "fs_extra",
@@ -839,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "libherokubuildpack"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba90e423e3407cb6c6f31f96f6b6eaa957d109c0113f3dd21bc985324f70835"
+checksum = "97818764bf0d76b98e76fdb3c585a9a02cef13baaad5a9901b6a3aaa2f374f86"
 dependencies = [
  "hex",
  "serde",
@@ -907,6 +917,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,14 +976,22 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
 dependencies = [
+ "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "opentelemetry",
  "percent-encoding",
  "rand",
  "thiserror",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "percent-encoding"
@@ -1279,6 +1307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,6 +1421,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1513,6 +1560,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1583,6 +1674,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -1679,6 +1776,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1807,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1830,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ unwrap_used = "warn"
 strip = true
 
 [workspace.dependencies]
-libcnb = { version = "0.27", features = ["trace"] }
-libcnb-test = "0.27"
-libherokubuildpack = { version = "0.27", default-features = false, features = [
+libcnb = { version = "0.28", features = ["trace"] }
+libcnb-test = "0.28"
+libherokubuildpack = { version = "0.28", default-features = false, features = [
     "inventory",
     "log",
     "inventory-sha2",

--- a/buildpacks/go/Cargo.toml
+++ b/buildpacks/go/Cargo.toml
@@ -18,6 +18,7 @@ sha2 = { workspace = true }
 tar = { version = "0.4", default-features = false }
 thiserror = { workspace = true }
 toml = { workspace = true }
+tracing = "0.1"
 ureq = { workspace = true }
 
 [dev-dependencies]

--- a/buildpacks/go/src/tgz.rs
+++ b/buildpacks/go/src/tgz.rs
@@ -43,7 +43,7 @@ pub(crate) enum Error {
 /// # Errors
 ///
 /// See `Error` for an enumeration of error scenarios.
-#[instrument(name = "download_go", err)]
+#[instrument(name = "download-go", err)]
 pub(crate) fn fetch_strip_filter_extract_verify<
     'a,
     D: Digest + std::fmt::Debug,

--- a/buildpacks/go/src/tgz.rs
+++ b/buildpacks/go/src/tgz.rs
@@ -4,9 +4,9 @@ use sha2::{
     digest::{generic_array::GenericArray, OutputSizeUser},
     Digest,
 };
-use tracing::instrument;
 use std::{fs, io::Read, path::StripPrefixError};
 use tar::Archive;
+use tracing::instrument;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {
@@ -44,7 +44,11 @@ pub(crate) enum Error {
 ///
 /// See `Error` for an enumeration of error scenarios.
 #[instrument(name = "download_go", err)]
-pub(crate) fn fetch_strip_filter_extract_verify<'a, D: Digest + std::fmt::Debug, V: std::fmt::Debug>(
+pub(crate) fn fetch_strip_filter_extract_verify<
+    'a,
+    D: Digest + std::fmt::Debug,
+    V: std::fmt::Debug,
+>(
     artifact: &Artifact<V, D, Option<()>>,
     strip_prefix: impl AsRef<str> + std::fmt::Debug,
     filter_prefixes: impl Iterator<Item = &'a str> + std::fmt::Debug,

--- a/buildpacks/go/src/tgz.rs
+++ b/buildpacks/go/src/tgz.rs
@@ -4,6 +4,7 @@ use sha2::{
     digest::{generic_array::GenericArray, OutputSizeUser},
     Digest,
 };
+use tracing::instrument;
 use std::{fs, io::Read, path::StripPrefixError};
 use tar::Archive;
 
@@ -42,11 +43,12 @@ pub(crate) enum Error {
 /// # Errors
 ///
 /// See `Error` for an enumeration of error scenarios.
-pub(crate) fn fetch_strip_filter_extract_verify<'a, D: Digest, V>(
+#[instrument(name = "download_go", err)]
+pub(crate) fn fetch_strip_filter_extract_verify<'a, D: Digest + std::fmt::Debug, V: std::fmt::Debug>(
     artifact: &Artifact<V, D, Option<()>>,
-    strip_prefix: impl AsRef<str>,
-    filter_prefixes: impl Iterator<Item = &'a str>,
-    dest_dir: impl AsRef<std::path::Path>,
+    strip_prefix: impl AsRef<str> + std::fmt::Debug,
+    filter_prefixes: impl Iterator<Item = &'a str> + std::fmt::Debug,
+    dest_dir: impl AsRef<std::path::Path> + std::fmt::Debug,
 ) -> Result<(), Error> {
     let destination = dest_dir.as_ref();
     let body = ureq::get(artifact.url.as_ref())


### PR DESCRIPTION
This brings in the latest libcnb, complete with `tracing` pipeline support. With this new support, we can now `#[instrument]` functions with spans and errors that will be available for the export pipeline. Downloading the go distribution is one of the first areas I'd like to instrument. `instrument` functionality generally wants `std::fmt::Debug` for arguments and any errors, so there was a change to function signatures.