### PR TITLE
Fix Clippy errors with Rust 1.86

### DIFF
--- a/common/go-utils/src/vrs.rs
+++ b/common/go-utils/src/vrs.rs
@@ -110,7 +110,7 @@ impl TryFrom<String> for GoVersion {
         if let Some(pre) = caps.get(4) {
             composed_version.push('-');
             composed_version.push_str(pre.as_str());
-        };
+        }
         let semantic_version = semver::Version::parse(&composed_version)?;
         Ok(GoVersion {
             value,


### PR DESCRIPTION
To unblock #365.

Fixes:

```
 error: unnecessary semicolon
   --> common/go-utils/src/vrs.rs:113:10
    |
113 |         };
    |          ^ help: remove
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon
    = note: `-D clippy::unnecessary-semicolon` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_semicolon)]`
```