### PR TITLE
Fix PR URL in CHANGELOG

### DIFF
--- a/buildpacks/go/CHANGELOG.md
+++ b/buildpacks/go/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update build output style ([#368](https://github.com/heroku/buildpacks-php/pull/368))
+- Update build output style ([#368](https://github.com/heroku/buildpacks-go/pull/368))
 
 ## [0.5.8] - 2025-04-02
 


### PR DESCRIPTION
The changelog entry for #368 was linking to a PR in the PHP CNB repo instead.