### PR TITLE
Remove Josh from CNB builder PR reviewers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
     with:
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
       dry_run: ${{ inputs.dry_run }}
-      reviewers: 'joshwlewis'
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
       cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
The reviewers field is optional - and will (indirectly) default to CODEOWNERS:
https://github.com/heroku/languages-github-actions/blob/v1.0.2/.github/workflows/_buildpacks-release.yml#L24-L27

GUS-W-18963252.