### PR TITLE
Add CNB_EXEC_ENV support for test execution env

### DIFF
--- a/buildpacks/go/CHANGELOG.md
+++ b/buildpacks/go/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support for `CNB_EXEC_ENV=test` environment variable to enable test execution mode. When set, the Go distribution is available at runtime. This enables Heroku CI support for the classic buildpack wrapper.
+- Added support for `CNB_EXEC_ENV=test` environment variable to enable test execution mode. When set, the Go distribution and module cache are available at runtime. This enables Heroku CI support for the classic buildpack wrapper.
 
 ## [2.2.2] - 2026-04-08
 

--- a/buildpacks/go/CHANGELOG.md
+++ b/buildpacks/go/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `CNB_EXEC_ENV=test` environment variable to enable test execution mode. When set, the Go distribution is available at runtime. This enables Heroku CI support for the classic buildpack wrapper.
+
 ## [2.2.2] - 2026-04-08
 
 ### Added

--- a/buildpacks/go/src/cfg.rs
+++ b/buildpacks/go/src/cfg.rs
@@ -40,10 +40,8 @@ pub(crate) fn read_gomod_config<P: AsRef<path::Path>>(
             (Some("//"), Some("+heroku"), Some("goVersion"), Some(vrs)) => {
                 version = parse_go_version_requirement(vrs).map(Some)?;
             }
-            (Some("go"), Some(vrs), None, None) => {
-                if version.is_none() {
-                    version = parse_go_version_requirement(&format!("={vrs}")).map(Some)?;
-                }
+            (Some("go"), Some(vrs), None, None) if version.is_none() => {
+                version = parse_go_version_requirement(&format!("={vrs}")).map(Some)?;
             }
             _ => (),
         }

--- a/buildpacks/go/src/exec_env.rs
+++ b/buildpacks/go/src/exec_env.rs
@@ -1,0 +1,69 @@
+use libcnb::Env;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExecutionEnvironment {
+    Production,
+    Test,
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "Unsupported execution environment: `CNB_EXEC_ENV={value}`. Supported values are `production` and `test`."
+)]
+pub(crate) struct ExecutionEnvironmentError {
+    pub(crate) value: String,
+}
+
+impl ExecutionEnvironment {
+    pub(crate) fn from_env(env: &Env) -> Result<Self, ExecutionEnvironmentError> {
+        match env.get_string_lossy("CNB_EXEC_ENV").as_deref() {
+            None | Some("production") => Ok(ExecutionEnvironment::Production),
+            Some("test") => Ok(ExecutionEnvironment::Test),
+            Some(other) => Err(ExecutionEnvironmentError {
+                value: other.to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_env_not_set() {
+        assert_eq!(
+            ExecutionEnvironment::from_env(&Env::new()),
+            Ok(ExecutionEnvironment::Production)
+        );
+    }
+
+    #[test]
+    fn test_from_env_production() {
+        let mut env = Env::new();
+        env.insert("CNB_EXEC_ENV", "production");
+        assert_eq!(
+            ExecutionEnvironment::from_env(&env),
+            Ok(ExecutionEnvironment::Production)
+        );
+    }
+
+    #[test]
+    fn test_from_env_test() {
+        let mut env = Env::new();
+        env.insert("CNB_EXEC_ENV", "test");
+        assert_eq!(
+            ExecutionEnvironment::from_env(&env),
+            Ok(ExecutionEnvironment::Test)
+        );
+    }
+
+    #[test]
+    fn test_from_env_invalid() {
+        let mut env = Env::new();
+        env.insert("CNB_EXEC_ENV", "invalid");
+        let result = ExecutionEnvironment::from_env(&env);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().value, "invalid");
+    }
+}

--- a/buildpacks/go/src/layers/deps.rs
+++ b/buildpacks/go/src/layers/deps.rs
@@ -1,3 +1,4 @@
+use crate::exec_env::ExecutionEnvironment;
 use crate::{GoBuildpack, GoBuildpackError};
 use bullet_stream::global::print;
 use libcnb::build::BuildContext;
@@ -28,12 +29,15 @@ pub(crate) enum DepsLayerError {
 /// Create or restore the layer for the go modules cache (non-vendored dependencies)
 pub(crate) fn handle_deps_layer(
     context: &BuildContext<GoBuildpack>,
+    exec_env: ExecutionEnvironment,
 ) -> libcnb::Result<LayerEnv, GoBuildpackError> {
+    let launch = matches!(exec_env, ExecutionEnvironment::Test);
+
     let layer_ref = context.cached_layer(
         layer_name!("go_deps"),
         CachedLayerDefinition {
             build: true,
-            launch: false,
+            launch,
             invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
             restored_layer_action: &|restored_metadata: &DepsLayerMetadata, _| {
                 if restored_metadata.cache_usage_count >= MAX_CACHE_USAGE_COUNT {
@@ -71,7 +75,7 @@ pub(crate) fn handle_deps_layer(
             let cache_dir = layer_ref.path().join(CACHE_DIR);
             fs::create_dir(&cache_dir).map_err(DepsLayerError::Create)?;
             layer_ref.write_env(LayerEnv::new().chainable_insert(
-                Scope::Build,
+                if launch { Scope::All } else { Scope::Build },
                 libcnb::layer_env::ModificationBehavior::Override,
                 CACHE_ENV,
                 cache_dir,

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -119,7 +119,7 @@ impl Buildpack for GoBuildpack {
         if Path::exists(&context.app_dir.join("vendor").join("modules.txt")) {
             print::sub_bullet("Using vendored Go modules");
         } else {
-            go_env = handle_deps_layer(&context)?.apply(Scope::Build, &go_env);
+            go_env = handle_deps_layer(&context, exec_env)?.apply(Scope::Build, &go_env);
         }
 
         go_env = handle_target_layer(&context)?.apply(Scope::Build, &go_env);

--- a/buildpacks/go/src/main.rs
+++ b/buildpacks/go/src/main.rs
@@ -5,12 +5,14 @@
 
 mod cfg;
 mod cmd;
+mod exec_env;
 mod layers;
 mod proc;
 mod tgz;
 
 use bullet_stream::global::print;
 use bullet_stream::style;
+use exec_env::{ExecutionEnvironment, ExecutionEnvironmentError};
 use heroku_go_utils::vrs::GoVersion;
 use indoc::formatdoc;
 use layers::build::{BuildLayerError, handle_build_layer};
@@ -66,7 +68,11 @@ impl Buildpack for GoBuildpack {
         print::bullet("Reading build configuration");
 
         let started = Instant::now();
-        let mut go_env = Env::from_current();
+        let go_env = Env::from_current();
+        let exec_env =
+            ExecutionEnvironment::from_env(&go_env).map_err(GoBuildpackError::ExecutionEnv)?;
+
+        let mut go_env = go_env;
         let go_prefixed_envs = go_env
             .iter()
             .map(|(key, _)| key.to_string_lossy())
@@ -105,7 +111,7 @@ impl Buildpack for GoBuildpack {
         ));
 
         print::bullet("Installing Go distribution");
-        go_env = handle_dist_layer(&context, artifact)?
+        go_env = handle_dist_layer(&context, artifact, exec_env)?
             .read_env()?
             .apply(Scope::Build, &go_env);
 
@@ -149,6 +155,10 @@ impl Buildpack for GoBuildpack {
             }
         }
 
+        if matches!(exec_env, ExecutionEnvironment::Test) {
+            print::bullet("Go toolchain available at runtime");
+        }
+
         print::all_done(&Some(started));
         BuildResultBuilder::new()
             .launch(LaunchBuilder::new().processes(procs).build())
@@ -163,6 +173,7 @@ impl Buildpack for GoBuildpack {
                     GoBuildpackError::BuildLayer(_) => "build layer",
                     GoBuildpackError::DepsLayer(_) => "dependency layer",
                     GoBuildpackError::DistLayer(_) => "distribution layer",
+                    GoBuildpackError::ExecutionEnv(_) => "execution environment",
                     GoBuildpackError::TargetLayer(_) => "target layer",
                     GoBuildpackError::GoModConfig(_) => "go.mod",
                     GoBuildpackError::InventoryParse(_) => "inventory parse",
@@ -186,6 +197,8 @@ impl Buildpack for GoBuildpack {
 enum GoBuildpackError {
     #[error("{0}")]
     BuildLayer(#[from] BuildLayerError),
+    #[error("{0}")]
+    ExecutionEnv(#[from] ExecutionEnvironmentError),
     #[error("Couldn't run `go build`: {0}")]
     GoBuild(cmd::Error),
     #[error("Couldn't run `go list`: {0}")]

--- a/buildpacks/go/tests/fixtures/go_test_125/go.mod
+++ b/buildpacks/go/tests/fixtures/go_test_125/go.mod
@@ -1,0 +1,5 @@
+module example.com/go_test_125
+
+// +heroku goVersion ~1.25.0
+
+go 1.25

--- a/buildpacks/go/tests/fixtures/go_test_125/go.mod
+++ b/buildpacks/go/tests/fixtures/go_test_125/go.mod
@@ -3,3 +3,7 @@ module example.com/go_test_125
 // +heroku goVersion ~1.25.0
 
 go 1.25
+
+require github.com/samber/lo v1.53.0
+
+require golang.org/x/text v0.22.0

--- a/buildpacks/go/tests/fixtures/go_test_125/go.sum
+++ b/buildpacks/go/tests/fixtures/go_test_125/go.sum
@@ -1,0 +1,4 @@
+github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
+github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
+golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
+golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=

--- a/buildpacks/go/tests/fixtures/go_test_125/main.go
+++ b/buildpacks/go/tests/fixtures/go_test_125/main.go
@@ -1,0 +1,27 @@
+//go:build heroku
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+func Add(a, b int) int {
+	return a + b
+}
+
+func root(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(w, "go_test_125")
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	http.HandleFunc("/", root)
+	http.ListenAndServe(":"+port, nil)
+}

--- a/buildpacks/go/tests/fixtures/go_test_125/main.go
+++ b/buildpacks/go/tests/fixtures/go_test_125/main.go
@@ -6,10 +6,16 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+
+	"github.com/samber/lo"
 )
 
 func Add(a, b int) int {
 	return a + b
+}
+
+func Sum(nums []int) int {
+	return lo.Sum(nums)
 }
 
 func root(w http.ResponseWriter, req *http.Request) {

--- a/buildpacks/go/tests/fixtures/go_test_125/main_test.go
+++ b/buildpacks/go/tests/fixtures/go_test_125/main_test.go
@@ -1,0 +1,12 @@
+//go:build heroku
+
+package main
+
+import "testing"
+
+func TestAdd(t *testing.T) {
+	got := Add(2, 3)
+	if got != 5 {
+		t.Errorf("Add(2, 3) = %d; want 5", got)
+	}
+}

--- a/buildpacks/go/tests/fixtures/go_test_125/main_test.go
+++ b/buildpacks/go/tests/fixtures/go_test_125/main_test.go
@@ -10,3 +10,10 @@ func TestAdd(t *testing.T) {
 		t.Errorf("Add(2, 3) = %d; want 5", got)
 	}
 }
+
+func TestSum(t *testing.T) {
+	got := Sum([]int{1, 2, 3, 4})
+	if got != 10 {
+		t.Errorf("Sum([]int{1,2,3,4}) = %d; want 10", got)
+	}
+}

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -236,7 +236,7 @@ fn test_environment_variables_passed_to_subprocesses() {
 #[test]
 #[ignore = "integration test"]
 fn test_cnb_exec_env_test() {
-    let mut build_config: BuildConfig = IntegrationTestConfig::new("basic_http_122").into();
+    let mut build_config: BuildConfig = IntegrationTestConfig::new("go_test_125").into();
     build_config.env("CNB_EXEC_ENV", "test");
 
     TestRunner::default().build(build_config, |ctx| {
@@ -244,6 +244,12 @@ fn test_cnb_exec_env_test() {
         assert_contains!(logs, "Go toolchain available at runtime");
 
         let output = ctx.run_shell_command("go version").stdout;
-        assert_contains!(output, "go version go1.22.");
+        assert_contains!(output, "go version go1.25.");
+
+        let gomodcache = ctx.run_shell_command("printenv GOMODCACHE").stdout;
+        assert_contains!(gomodcache, "go_deps");
+
+        let test_output = ctx.run_shell_command("go test -v -tags heroku ./...").stdout;
+        assert_contains!(test_output, "PASS");
     });
 }

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -232,3 +232,18 @@ fn test_environment_variables_passed_to_subprocesses() {
         });
     });
 }
+
+#[test]
+#[ignore = "integration test"]
+fn test_cnb_exec_env_test() {
+    let mut build_config: BuildConfig = IntegrationTestConfig::new("basic_http_122").into();
+    build_config.env("CNB_EXEC_ENV", "test");
+
+    TestRunner::default().build(build_config, |ctx| {
+        let logs = format!("{}\n{}", ctx.pack_stdout, ctx.pack_stderr);
+        assert_contains!(logs, "Go toolchain available at runtime");
+
+        let output = ctx.run_shell_command("go version").stdout;
+        assert_contains!(output, "go version go1.22.");
+    });
+}

--- a/buildpacks/go/tests/integration_test.rs
+++ b/buildpacks/go/tests/integration_test.rs
@@ -249,7 +249,7 @@ fn test_cnb_exec_env_test() {
         let gomodcache = ctx.run_shell_command("printenv GOMODCACHE").stdout;
         assert_contains!(gomodcache, "go_deps");
 
-        let test_output = ctx.run_shell_command("go test -v -tags heroku ./...").stdout;
-        assert_contains!(test_output, "PASS");
+        let test_output = ctx.run_shell_command("go test -tags heroku ./...").stdout;
+        assert_contains!(test_output, "ok");
     });
 }


### PR DESCRIPTION
When `CNB_EXEC_ENV=test` is set, the go toolchain and modules are left on the image so they can be invoked later.

This pattern is used via the dotnet buildpack which uses a "wrapper" around the CNB to provide a classic buildpack. This is used in `bin/test-compile` to toggle on/off behavior needed for `bin/test` (a feature only found in classic buildpacks and not yet on CNBs).

https://github.com/heroku/heroku-buildpack-dotnet/blob/7e12de5d9b432356bd2b1783a500cd01be4632b3/bin/test-compile#L10.

GUS-W-21034885