### PR TITLE
Drop `--trust-builder` flag from `print-output` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           set euo --pipefail
           echo "## Getting Started output" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          pack build my-image --force-color --builder heroku/builder:26 --trust-builder --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_go --path tmp/guide --pull-policy never \
+          pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_go --path tmp/guide --pull-policy never \
             |& tee >(sed -e 's/\x1b\[[0-9;]*m//g' >> $GITHUB_STEP_SUMMARY)
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: "PRINT: Cached getting started guide output"
@@ -160,6 +160,6 @@ jobs:
           set -euo pipefail
           echo "## Cached Output" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          pack build my-image --force-color --builder heroku/builder:26 --trust-builder --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_go --path tmp/guide --pull-policy never \
+          pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_go --path tmp/guide --pull-policy never \
             |& tee >(sed -e 's/\x1b\[[0-9;]*m//g' >> $GITHUB_STEP_SUMMARY)
           echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
`heroku/builder:26` is now on pack's [trusted builders list](https://github.com/buildpacks/pack/pull/2569), shipped in pack v0.40.6, which is the default in [buildpacks/github-actions v5.12.3](https://github.com/buildpacks/github-actions/releases/tag/v5.12.3) — already pinned here as of #475. So `--trust-builder` can go.

GUS-W-22518634