### PR TITLE
Update default builder in README to heroku/builder:26

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build a Go application codebase into a production image:
 
 ```bash
 $ cd ~/workdir/sample-go-app
-$ pack build sample-app --builder heroku/builder:24
+$ pack build sample-app --builder heroku/builder:26
 ```
 
 Then run the image:


### PR DESCRIPTION
The integration test default builder is already heroku/builder:26;
this brings the README usage example in line.

GUS-W-22580946.